### PR TITLE
Make endpoint creation independent of device configuration

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
@@ -91,6 +91,34 @@ async def tgen_utils_get_swp_info(dent_dev, swp, swp_info):
     await _get_iface_addr_info(dent_dev, swp, swp_info)
 
 
+def tgen_utils_dev_groups_from_config(config):
+    """
+    - Creates a device group dict that can be used in *_traffic_generator_connect
+    - Expects config to be a list of dicts:
+    [
+        {
+            "ixp": tgen port,
+            "ip": tgen port ip to be configured,
+            "gw": peer ip,
+            "plen": prefix length,
+        },
+        ...
+    ]
+    """
+    dev_groups = {}
+    for el in config:
+        if not dev_groups.get(el["ixp"], None):
+            dev_groups[el["ixp"]] = []
+        dev_groups[el["ixp"]].append({
+            "name": f'{el["ixp"]}_{el["ip"]}/{el["plen"]}',
+            "count": 1,
+            "ip": el["ip"],
+            "gw": el["gw"],
+            "plen": el["plen"],
+        })
+    return dev_groups
+
+
 async def tgen_utils_traffic_generator_connect(device, tgen_ports, swp_ports, dev_groups):
     """
     - Connects to the tgen


### PR DESCRIPTION
Move `TrafficGen.connect()` to a separate function, so it can be reused, and remove duplicate code.
Introduce a new helper function that is used to create a device group config which can be used in `TrafficGen.connect()`.

Example usage:
```python
dev_groups = tgen_utils_dev_groups_from_config([
    {"ixp": tg_port[0], "ip": "192.168.1.2", "gw": "192.168.1.1", "plen": 24},
    {"ixp": tg_port[1], "ip": "192.168.2.2", "gw": "192.168.2.1", "plen": 24},
])
await tgen_utils_traffic_generator_connect(tgen_dev, tgen_ports, swp_ports, dev_groups)
```

Resolves: https://github.com/dentproject/testing/issues/63

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>