### PR TITLE
Add output parser to IpNeighborImpl

### DIFF
--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_neighbor_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_neighbor_impl.py
@@ -1,3 +1,5 @@
+import json
+
 from dent_os_testbed.lib.ip.linux.linux_ip_neighbor import LinuxIpNeighbor
 
 
@@ -44,3 +46,6 @@ class LinuxIpNeighborImpl(LinuxIpNeighbor):
             cmd += "nud {} ".format(params["nud"])
 
         return cmd
+
+    def parse_show(self, command, output, *argv, **kwarg):
+        return json.loads(output)


### PR DESCRIPTION
This will allow to use the `parse_output=True` argument with the `IpNeighbor` class. Example:

```python
out = await IpNeighbor.show(input_data=[{dent: [{"cmd_options": "-j"}]}], parse_output=True)
print(out[0][dent]["parsed_output"])  # [ ... ]
```

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>