### PR TITLE
Add ability to configure bi-directional traffic

### DIFF
--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -362,6 +362,7 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             IxnetworkIxiaClientImpl.tis.append(ti)
             ti.Tracking.find()[0].TrackBy = ["trackingenabled0", "sourceDestValuePair0"]
             ti.Enabled = True
+            ti.BiDirectional = pkt_data.get("bi_directional", False)
             for ep in range(ep_count):
                 config_element = ti.ConfigElement.find(EndpointSetId=ep + 1)
                 # set the rate


### PR DESCRIPTION
When setuping streams set the `bi_directional` flag to enable bi-directional traffic flow:

```python
streams = {
    "traffic": {
        "type": "ipv4",
        "bi_directional": True,
        ...
    },
}
await tgen_utils_setup_streams(tgen_dev, config_file_name, streams)
```

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>