### PR TITLE
remove pexpectasyncio

### DIFF
--- a/DentOS_Framework/DentOsTestbed/Requirements.txt
+++ b/DentOS_Framework/DentOsTestbed/Requirements.txt
@@ -3,7 +3,6 @@ asyncssh
 aiofiles
 aiohttp
 pexpect
-pexpectasyncio
 pytest
 pytest-asyncio
 pytest-html


### PR DESCRIPTION
pexpectasyncio does not exist in pypi removing for now as it is not used anywhere