### PR TITLE
replace eth0 with ma1

### DIFF
--- a/DentOS_Framework/DentOsTestbed/configuration/README.md
+++ b/DentOS_Framework/DentOsTestbed/configuration/README.md
@@ -22,7 +22,7 @@ Test Bed configuration file format
             "serialDev":"/dev/ttyUSB6",        # Serial console access
             "baudrate": 115200,                # Baud rate
             "links" : [                        # Link details
-                ["eth0", "oob_sw2:swp40"],     # ["local port", "remote port:remote port"]
+                ["ma1", "oob_sw2:swp40"],     # ["local port", "remote port:remote port"]
                 ...
             ]
 

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/basic/infra_sw1/infra_sw1_NETWORK_INTERFACES
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/basic/infra_sw1/infra_sw1_NETWORK_INTERFACES
@@ -12,8 +12,8 @@ iface lo inet loopback
     address 20.2.0.101/32
 
 # The management interface
-auto eth0
-iface eth0 inet dhcp
+auto ma1
+iface ma1 inet dhcp
 
 auto vlan100
 iface vlan100 inet static

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/basic/infra_sw1/infra_sw1_NTP
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/basic/infra_sw1/infra_sw1_NTP
@@ -54,7 +54,7 @@ restrict ::1
 #broadcastclient
 
 # Specify interfaces, don't listen on switch ports
-#interface listen eth0
+#interface listen ma1
 interface listen lo
 interface listen lo:0
 interface listen dummy0

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg_r1/agg_r1_NETWORK_INTERFACES
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg_r1/agg_r1_NETWORK_INTERFACES
@@ -12,8 +12,8 @@ iface lo inet loopback
     address 20.20.0.3/32
 
 # The management interface
-auto eth0
-iface eth0 inet dhcp
+auto ma1
+iface ma1 inet dhcp
 
 auto swp1
 iface swp1 inet static

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg_r1/agg_r1_NTP
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg_r1/agg_r1_NTP
@@ -54,7 +54,7 @@ restrict ::1
 #broadcastclient
 
 # Specify interfaces, don't listen on switch ports
-#interface listen eth0
+#interface listen ma1
 interface listen lo
 interface listen lo:0
 interface listen dummy0

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg_r2/agg_r2_NETWORK_INTERFACES
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg_r2/agg_r2_NETWORK_INTERFACES
@@ -12,8 +12,8 @@ iface lo inet loopback
     address 20.20.0.4/32
 
 # The management interface
-auto eth0
-iface eth0 inet dhcp
+auto ma1
+iface ma1 inet dhcp
 
 auto swp1
 iface swp1 inet static

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg_r2/agg_r2_NTP
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg_r2/agg_r2_NTP
@@ -54,7 +54,7 @@ restrict ::1
 #broadcastclient
 
 # Specify interfaces, don't listen on switch ports
-#interface listen eth0
+#interface listen ma1
 interface listen lo
 interface listen lo:0
 interface listen dummy0

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/dis_r1/dis_r1_NETWORK_INTERFACES
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/dis_r1/dis_r1_NETWORK_INTERFACES
@@ -12,8 +12,8 @@ iface lo inet loopback
     address 20.20.0.1/32
 
 # The management interface
-auto eth0
-iface eth0 inet dhcp
+auto ma1
+iface ma1 inet dhcp
 
 auto swp1
 iface swp1 inet static

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/dis_r1/dis_r1_NTP
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/dis_r1/dis_r1_NTP
@@ -54,7 +54,7 @@ restrict ::1
 #broadcastclient
 
 # Specify interfaces, don't listen on switch ports
-#interface listen eth0
+#interface listen ma1
 interface listen lo
 interface listen lo:0
 interface listen dummy0

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra_sw1/infra_sw1_NETWORK_INTERFACES
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra_sw1/infra_sw1_NETWORK_INTERFACES
@@ -12,8 +12,8 @@ iface lo inet loopback
     address 20.20.0.101/32
 
 # The management interface
-auto eth0
-iface eth0 inet dhcp
+auto ma1
+iface ma1 inet dhcp
 
 auto swp49
 iface swp49 inet static

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra_sw1/infra_sw1_NTP
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra_sw1/infra_sw1_NTP
@@ -54,7 +54,7 @@ restrict ::1
 #broadcastclient
 
 # Specify interfaces, don't listen on switch ports
-#interface listen eth0
+#interface listen ma1
 interface listen lo
 interface listen lo:0
 interface listen dummy0

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra_sw2/infra_sw2_NETWORK_INTERFACES
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra_sw2/infra_sw2_NETWORK_INTERFACES
@@ -12,8 +12,8 @@ iface lo inet loopback
     address 20.20.0.102/32
 
 # The management interface
-auto eth0
-iface eth0 inet dhcp
+auto ma1
+iface ma1 inet dhcp
 
 auto swp49
 iface swp49 inet static

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra_sw2/infra_sw2_NTP
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra_sw2/infra_sw2_NTP
@@ -54,7 +54,7 @@ restrict ::1
 #broadcastclient
 
 # Specify interfaces, don't listen on switch ports
-#interface listen eth0
+#interface listen ma1
 interface listen lo
 interface listen lo:0
 interface listen dummy0

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/alpha/static_routing/test_kernel_route.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/alpha/static_routing/test_kernel_route.py
@@ -32,7 +32,7 @@ async def test_alpha_lab_static_routing_kernel_route_on_table(testbed):
     Test Procedure:
     1. Kernel route impact on table
     2. test interaction of a kernel route on network
-    3. on eth0 set up dhcp server to send ip and default route and monitor
+    3. on ma1 set up dhcp server to send ip and default route and monitor
     4.  install a static route to tgen port
     5.. then send the packet it should show up in tgen port.
     """
@@ -43,7 +43,7 @@ async def test_alpha_lab_static_routing_kernel_route_on_table(testbed):
     dent_dev = dent_devices[0]
     dent = dent_dev.host_name
     swp_tgen_ports = tgen_dev.links_dict[dent][1]
-    swp = "eth0"
+    swp = "ma1"
 
     out = await IpLink.show(
         input_data=[{dent: [{"device": swp, "cmd_options": "-j"}]}],

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/sanity_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/sanity_utils.py
@@ -48,9 +48,9 @@ async def check_routes(dev, devices_dict):
         # add exceptions
         dev.applog.info(f"checking route {dst} exceptions")
         # no device
-        port = route.get("dev", "eth0")
+        port = route.get("dev", "ma1")
         # mgmt interfces
-        if port in ["eth0"]:
+        if port in ["ma1"]:
             continue
         if port.startswith("vlan") and port.endswith("-v0"):
             continue

--- a/DentOS_Framework/DentOsTestbedLib/gen/model/dent/network/bridge/bridge.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/dent/network/bridge/bridge.yaml
@@ -43,8 +43,8 @@
           BPDU processing. Turning this flag on will disables the bridge port if a STP BPDU packet is received.
           If running Spanning Tree on bridge, hostile devices on the network may send BPDU on a port and cause network
           failure. Setting guard on will detect and stop this by disabling the port. The port will be restarted if link
-          is brought down, or removed and reattached. For example if guard is enable on eth0:
-          ip link set dev eth0 down; ip link set dev eth0 up
+          is brought down, or removed and reattached. For example if guard is enable on ma1:
+          ip link set dev ma1 down; ip link set dev ma1 up
       - name: hairpin
         type: bool
         desc: |

--- a/DentOS_Framework/DentOsTestbedLib/gen/model/dent/network/ip/address.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/dent/network/ip/address.yaml
@@ -86,7 +86,7 @@
           label NAME --- Each address may be tagged with a label string. In order
           to preserve compatibility with Linux-2.0 net aliases, this string must
           coincide with the name of the device or must be prefixed with device name
-          followed by a colon. (eth0:duh)
+          followed by a colon. (ma1:duh)
 
       - name: scope
         type: int

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/interfaces/linux/linux_interface_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/interfaces/linux/linux_interface_impl.py
@@ -46,13 +46,13 @@ class LinuxInterfaceImpl(LinuxInterface):
         if "options" in params:
             cmd += "{} ".format(params["options"])
         if "exclude_iface" in params:
-            # ifdown -X eth0 -X lo -a
+            # ifdown -X ma1 -X lo -a
             for e in params["exclude_iface"]:
                 cmd += "-X {} ".format(e)
         if "force" in params and params["force"]:
             cmd += "-f "
         if "iface" in params:
-            # ifdown eth0 lo
+            # ifdown ma1 lo
             for i in params["iface"]:
                 cmd += "{} ".format(i)
 
@@ -118,7 +118,7 @@ class LinuxInterfaceImpl(LinuxInterface):
         if "options" in params:
             cmd += "{} ".format(params["options"])
         if "exclude_iface" in params:
-            # ifdown -X eth0 -X lo -a
+            # ifdown -X ma1 -X lo -a
             for e in params["exclude_iface"]:
                 cmd += "-X {} ".format(e)
 


### PR DESCRIPTION
eth0 gets renamed into ma1 when dentos 2.0 and 3.0 boots, eth0 does not exist