### PR TITLE
Update tgen_utils_dev_groups_from_config

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
@@ -101,6 +101,7 @@ def tgen_utils_dev_groups_from_config(config):
             "ip": tgen port ip to be configured,
             "gw": peer ip,
             "plen": prefix length,
+            "vlan": vlan id to be configured (optional),
         },
         ...
     ]
@@ -115,6 +116,7 @@ def tgen_utils_dev_groups_from_config(config):
             "ip": el["ip"],
             "gw": el["gw"],
             "plen": el["plen"],
+            "vlan": el.get("vlan", None),
         })
     return dev_groups
 


### PR DESCRIPTION
Add ability to specify vlan id, that will be configured on an endpoint.

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>