### PR TITLE
Add ability to send increment traffic

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
@@ -407,6 +407,7 @@ async def tgen_utils_setup_streams(device, config_file_name, streams, force_upda
                 input_data=[{device.host_name: [{"name": s, "pkt_data": streams[s]}]}]
             )
             device.applog.info(out)
+            assert out[0][device.host_name]["rc"] == 0, "Setting tgen traffic failed.\n{out}"
         device.applog.info(f"Saving Tgen config file {config_file_name}")
         out = await TrafficGen.save_config(
             input_data=[{device.host_name: [{"config_file_name": config_file_name}]}]


### PR DESCRIPTION
Update `IxnetworkIxiaClientImpl` class to accept new types of field values when creating streams.

When creating streams instead of specifying a string you can specify a dict that will describe what values you want the field to have:
```python
streams = {
    "stream_name": {
        "type": "raw",

        "srcMac": "02:00:00:00:00:01",
        "dstMac": {"type": "random"},
    }
}
await tgen_utils_setup_streams(tgen_dev, None, streams)
```

Fields that support this feature:
- dstMac
- srcMac
- vlanID
- dstIp
- srcIp
- dstPort
- srcPort
- icmpType
- icmpCode

Supported field types:
- single (default value, used when a string is passed instead of a dict)
- increment
- decrement
- list
- random

More examples:
```python
streams = {
    "stream_name": {
        "type": "raw",

        # same as "srcIp": "192.168.1.1"
        "srcIp": {"type": "single",
                  "value": "192.168.1.1"},

        "srcIp": {"type": "random",
                  "mask": "0.255.0.255"},

        "srcIp": {"type": "increment",
                  "start": "192.168.0.1",
                  "step": "0.0.1.0",
                  "count": 255},

        # mask has no effect on random MAC
        "srcMac": {"type": "random"},

        "srcMac": {"type": "decrement",
                   "start": "02:00:00:00:ff:00",
                   "step": "00:00:00:00:10:00",
                   "count": 15},

        "vlanID": {"type": "list",
                   "list": [10, 20, 30, 40, 50, 60]},
    }
}
```
Limitations:
- `mask` has no effect on mac addr when `random` type is used.
- `vlanID` does not support the `random` type.

Resolves: https://github.com/dentproject/testing/issues/98

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>