### PR TITLE
Add send_ping/send_arp interface for Ixia traffic gen

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
@@ -587,3 +587,68 @@ def tgen_utils_get_loss(row):
     if loss == "":
         return 0.0
     return float(loss)
+
+
+async def tgen_utils_send_ping(device, config):
+    """
+    - Sends ping from TG ports to DUT
+    - Expects config to be a list of dicts:
+    [
+        {
+            "ixp": tgen port,
+            "src_ip": tgen port ip (optional),
+            "dst_ip": peer ip,
+        },
+        ...
+    ]
+    - returns a list of dicts for each ping sent
+    [
+        {
+            "success": True or False,
+            "info": string,
+            "port": tg_port,
+            "src_ip": tg_port ip,
+            "dst_ip": peer ip,
+        },
+        ...
+    ]
+    """
+    out = await TrafficGen.send_ping(input_data=[{device.host_name: [
+        {"port": ping["ixp"],
+         "dst_ip": ping["dst_ip"],
+         "src_ip": ping["src_ip"] if "src_ip" in ping else None}
+        for ping in config
+    ]}])
+    if out[0][device.host_name]["rc"] != 0:
+        device.applog.warning(f"Some pings did not reach their destination\n{out}")
+    return out[0][device.host_name]["result"]
+
+
+async def tgen_utils_send_arp(device, config):
+    """
+    - Sends arp packets from TG ports to DUT
+    - Expects config to be a list of dicts:
+    [
+        {
+            "ixp": tgen port,
+            "src_ip": tgen port ip (optional),
+        },
+        ...
+    ]
+    - returns a list of dicts for each arp sent
+    [
+        {
+            "success": True or False,
+            "port": tg_port,
+            "src_ip": tg_port ip,
+        },
+        ...
+    ]
+    """
+    out = await TrafficGen.send_arp(input_data=[{device.host_name: [
+        {"port": arp["ixp"], "src_ip": arp["src_ip"] if "src_ip" in arp else None}
+        for arp in config
+    ]}])
+    if out[0][device.host_name]["rc"] != 0:
+        device.applog.warning(f"Some arps did not reach their destination\n{out}")
+    return out[0][device.host_name]["result"]

--- a/DentOS_Framework/DentOsTestbedLib/gen/model/dent/traffic/traffic.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/dent/traffic/traffic.yaml
@@ -31,10 +31,13 @@
           set_protocol - [protocol]
           get_protocol_stats - [protocols]
           clear_protocol_stats - [protocols]
+          send_ping - [port, dst_ip, src_ip]
+          send_arp - [port, src_ip]
      apis: ['connect', 'disconnect',
             'load_config', 'save_config',
             'set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats',
-            'start_protocols', 'stop_protocols', 'set_protocol',  'get_protocol_stats', 'clear_protocol_stats']
+            'start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats',
+            'clear_protocol_stats', 'send_arp', 'send_ping']
      members:
       - name: client_addr
         type: ip_addr_t
@@ -56,3 +59,11 @@
         type: string_list
         desc: |
           Traffic Generator Ports represented in "ip:slot:port"
+      - name: src_ip
+        type: ip_addr_t
+        desc: |
+          Host IP Address
+      - name: dst_ip
+        type: ip_addr_t
+        desc: |
+          Peer IP Address

--- a/DentOS_Framework/DentOsTestbedLib/gen/model/traffic/ixia/ixia.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/traffic/ixia/ixia.yaml
@@ -19,6 +19,8 @@
           set_protocol - [protocol]
           get_protocol_stats - [protocols]
           clear_protocol_stats - [protocols]
+          send_ping - [port, dst_ip, src_ip]
+          send_arp - [port, src_ip]
      implements: "dent:traffic:traffic_gen"
      platforms: ['ixnetwork']
      commands:
@@ -58,3 +60,15 @@
             set_protocol - [protocol]
             get_protocol_stats - [protocols]
             clear_protocol_stats - [protocols]
+      - name: send_ping
+        apis: ['send_ping']
+        params: ['ports', 'dst_ip', 'src_ip']
+        desc: |
+         - IxiaClient
+           send_ping - [port, dst_ip, src_ip]
+      - name: send_arp
+        apis: ['send_arp']
+        params: ['ports', 'src_ip']
+        desc: |
+         - IxiaClient
+           send_arp - [port, src_ip]

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/discovery/ReportSchema.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/discovery/ReportSchema.py
@@ -739,6 +739,8 @@ class TrafficGenSchemaDict(SchemaDict):
         "protocols":str,
         "traffic_names":str,
         "ports":str,
+        "src_ip":str,
+        "dst_ip":str,
 
     }
 class TestbedL3SchemaDict(SchemaDict):

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client.py
@@ -22,6 +22,8 @@ class IxnetworkIxiaClient(TestLibObject):
             set_protocol - [protocol]
             get_protocol_stats - [protocols]
             clear_protocol_stats - [protocols]
+            send_ping - [port, dst_ip, src_ip]
+            send_arp - [port, src_ip]
         
     """
     def format_connect(self, command, *argv, **kwarg):
@@ -60,6 +62,24 @@ class IxnetworkIxiaClient(TestLibObject):
     def parse_protocol(self, command, output, *argv, **kwarg):
         raise NotImplementedError
         
+    def format_send_ping(self, command, *argv, **kwarg):
+        raise NotImplementedError
+        
+    def run_send_ping(self, device, command, *argv, **kwarg):
+        raise NotImplementedError
+        
+    def parse_send_ping(self, command, output, *argv, **kwarg):
+        raise NotImplementedError
+        
+    def format_send_arp(self, command, *argv, **kwarg):
+        raise NotImplementedError
+        
+    def run_send_arp(self, device, command, *argv, **kwarg):
+        raise NotImplementedError
+        
+    def parse_send_arp(self, command, output, *argv, **kwarg):
+        raise NotImplementedError
+        
     def format_command(self, command, *argv, **kwarg):
         if command in ['connect', 'disconnect']:
             return self.format_connect(command, *argv, **kwarg)
@@ -72,6 +92,12 @@ class IxnetworkIxiaClient(TestLibObject):
         
         if command in ['start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats', 'clear_protocol_stats']:
             return self.format_protocol(command, *argv, **kwarg)
+        
+        if command in ['send_ping']:
+            return self.format_send_ping(command, *argv, **kwarg)
+        
+        if command in ['send_arp']:
+            return self.format_send_arp(command, *argv, **kwarg)
         
         
         raise NameError("Cannot find command "+command)
@@ -89,6 +115,12 @@ class IxnetworkIxiaClient(TestLibObject):
         if command in ['start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats', 'clear_protocol_stats']:
             return self.run_protocol(device_obj, command, *argv, **kwarg)
         
+        if command in ['send_ping']:
+            return self.run_send_ping(device_obj, command, *argv, **kwarg)
+        
+        if command in ['send_arp']:
+            return self.run_send_arp(device_obj, command, *argv, **kwarg)
+        
         
         print (len(command))
         raise NameError("Cannot find command "+command)
@@ -105,6 +137,12 @@ class IxnetworkIxiaClient(TestLibObject):
         
         if command in ['start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats', 'clear_protocol_stats']:
             return self.parse_protocol(command, output, *argv, **kwarg)
+        
+        if command in ['send_ping']:
+            return self.parse_send_ping(command, output, *argv, **kwarg)
+        
+        if command in ['send_arp']:
+            return self.parse_send_arp(command, output, *argv, **kwarg)
         
         
         raise NameError("Cannot find command "+command)

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -20,6 +20,8 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
         stop_protocols - [protocols]
         get_protocol_stats - [protocols]
         clear_protocol_stats - [protocols]
+        send_ping - [port, dst_ip, src_ip]
+        send_arp - [port, src_ip]
 
     """
 
@@ -481,3 +483,92 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
 
     def parse_protocol(self, command, output, *argv, **kwarg):
         return command
+
+    def format_send_ping(self, command, *argv, **kwarg):
+        return command
+
+    def format_send_arp(self, command, *argv, **kwarg):
+        return command
+
+    @classmethod
+    def __get_ip_iface(cls, port, port_ip=None):
+        vport = cls.ixnet.Vport.find(Name=port)
+        for ip_ep in cls.ip_eps:
+            # ip -> eth -> dev group -> topo
+            topo = ip_ep.parent.parent.parent
+            if vport.href not in topo.Ports:
+                continue
+            if port_ip and port_ip not in str(ip_ep.Address):
+                continue
+            return ip_ep
+        return None
+
+    def run_send_ping(self, device, command, *argv, **kwarg):
+        """
+        - IxiaClient
+           send_ping - [port, dst_ip, src_ip]
+        """
+        params = kwarg["params"]
+        res = []
+        err = 0
+        for param in params:
+            port = param["port"]
+            dst = param["dst_ip"]
+            src = param.get("src_ip", None)
+            out = {
+                "port": port,
+                "src_ip": src,
+                "dst_ip": dst,
+            }
+
+            ip_ep = self.__get_ip_iface(port, src)
+            if not ip_ep:
+                err_msg = f"Did not find IP endpoint {port} with ip {src}"
+                out["arg2"] = False
+                out["arg3"] = err_msg
+                device.applog.info(err_msg)
+            else:
+                device.applog.info(f"Sending Ping from {ip_ep.Name} to {dst}")
+                out.update(ip_ep.SendPing(DestIp=dst)[0])
+
+            res.append(out)
+            if not out["arg2"]:
+                err = 1
+
+        return err, [{"success": msg["arg2"],
+                      "info": msg["arg3"],
+                      "port": msg["port"],
+                      "src_ip": msg["src_ip"],
+                      "dst_ip": msg["dst_ip"]} for msg in res]
+
+    def run_send_arp(self, device, command, *argv, **kwarg):
+        """
+        - IxiaClient
+           send_arp - [port, src_ip]
+        """
+        params = kwarg["params"]
+        res = []
+        err = 0
+        for param in params:
+            port = param["port"]
+            src = param.get("src_ip", None)
+            out = {
+                "port": port,
+                "src_ip": src,
+            }
+
+            ip_ep = self.__get_ip_iface(port, src)
+            if not ip_ep:
+                out["arg2"] = False
+                device.applog.info(f"Did not find IP endpoint {port} with ip {src}")
+            else:
+                device.applog.info(f"Sending ARP from {ip_ep.Name}")
+                out.update(ip_ep.SendArp()[0])
+
+            res.append(out)
+            if not out["arg2"]:
+                err = 1
+
+        return err, [{"success": msg["arg2"],
+                      "port": msg["port"],
+                      "src_ip": msg["src_ip"]} for msg in res]

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/traffic_gen.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/traffic_gen.py
@@ -24,6 +24,8 @@ class TrafficGen(TestLibObject):
             set_protocol - [protocol]
             get_protocol_stats - [protocols]
             clear_protocol_stats - [protocols]
+            send_ping - [port, dst_ip, src_ip]
+            send_arp - [port, src_ip]
         
     """
     async def _run_command(api, *argv, **kwarg):
@@ -400,4 +402,47 @@ class TrafficGen(TestLibObject):
         
         """
         return await TrafficGen._run_command("clear_protocol_stats", *argv, **kwarg)
+        
+    async def send_arp(*argv, **kwarg):
+        """
+        Platforms: ['ixnetwork']
+        Usage:
+        TrafficGen.send_arp(
+            input_data = [{
+                # device 1
+                'dev1' : [{
+                    # command 1
+                        'ports':'string_list',
+                        'src_ip':'ip_addr_t',
+                }],
+            }],
+        )
+        Description:
+        - IxiaClient
+          send_arp - [port, src_ip]
+        
+        """
+        return await TrafficGen._run_command("send_arp", *argv, **kwarg)
+        
+    async def send_ping(*argv, **kwarg):
+        """
+        Platforms: ['ixnetwork']
+        Usage:
+        TrafficGen.send_ping(
+            input_data = [{
+                # device 1
+                'dev1' : [{
+                    # command 1
+                        'ports':'string_list',
+                        'dst_ip':'ip_addr_t',
+                        'src_ip':'ip_addr_t',
+                }],
+            }],
+        )
+        Description:
+        - IxiaClient
+          send_ping - [port, dst_ip, src_ip]
+        
+        """
+        return await TrafficGen._run_command("send_ping", *argv, **kwarg)
         


### PR DESCRIPTION
Update `traffic` and `ixia` yaml models.
Add two new APIs:
 - TrafficGen.send_ping()
 - TrafficGen.send_arp()

`send_ping()` accepts a list of tg_ports, destination ip, and optional source ip (in case that the port has multiple endpoints).
`send_arp()` accepts a list of tg_ports and optional source ip.

Usage:
```python
out = await TrafficGen.send_arp(input_data=[{tgen_dev.host_name: [
    {"port": tg_ports[0]},
    {"port": tg_ports[1], "src_ip": "2.2.2.2"},
]}])
assert out[0][tgen_dev.host_name]["rc"] == 0

out = await TrafficGen.send_ping(input_data=[{tgen_dev.host_name: [
    {"port": tg_ports[0], "dst_ip": "1.1.1.1"},
    {"port": tg_ports[1], "dst_ip": "2.2.2.1", "src_ip": "2.2.2.2"},
]}])
assert out[0][tgen_dev.host_name]["rc"] == 0

status = await tgen_utils_send_ping(
    tgen_dev,
    [{"ixp": tg_ports[0], "dst_ip": "1.1.1.1"}],
)
print(status)  # [ {"success": True, ...}, ... ]
```

Resolves: https://github.com/dentproject/testing/issues/91

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>