### PR TITLE
Make "Source/Dest Value Pair" optional in get_traffic_stats

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
@@ -453,12 +453,13 @@ async def tgen_utils_get_traffic_stats(device, stats_type="Port Statistics"):
                 )
             )
         elif stats_type == "Flow Statistics":
+            sip_dip = "Source/Dest Value Pair"
             device.applog.info(
                 "Tx {} Rx {} TI {} SIP-DIP {} Tx {} Rx {} Loss {}".format(
                     row["Tx Port"],
                     row["Rx Port"],
                     row["Traffic Item"],
-                    row["Source/Dest Value Pair"],
+                    row[sip_dip] if sip_dip in row.Columns else "N/A",
                     row["Tx Frames"],
                     row["Rx Frames"],
                     row["Loss %"],


### PR DESCRIPTION
When sending "raw" traffic type the "Source/Dest Value Pair" field is not present, which causes a "KeyError" exception.

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>