### PR TITLE
Add Egress tracking

### DIFF
--- a/DentOS_Framework/DentOsTestbedLib/gen/model/dent/traffic/traffic.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/dent/traffic/traffic.yaml
@@ -25,6 +25,7 @@
           start_traffic - [traffic_names]
           stop_traffic  - [traffic_names]
           get_stats - [traffic_names]
+          get_drilldown_stats - [traffic_names]
           clear_stats - [traffic_names]
           start_protocols - [protocols]
           stop_protocols - [protocols]
@@ -38,7 +39,7 @@
            'load_config', 'save_config',
            'set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats',
            'start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats',
-           'clear_protocol_stats', 'send_arp', 'send_ping', 'clear_traffic']
+           'clear_protocol_stats', 'send_arp', 'send_ping', 'clear_traffic', 'get_drilldown_stats']
     members:
     - name: client_addr
       type: ip_addr_t

--- a/DentOS_Framework/DentOsTestbedLib/gen/model/traffic/ixia/ixia.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/traffic/ixia/ixia.yaml
@@ -41,7 +41,7 @@
             save_config - config_file_name
       - name: traffic_item
         apis: ['set_traffic', 'start_traffic', 'stop_traffic',
-               'get_stats', 'clear_stats', 'clear_traffic']
+               'get_stats', 'clear_stats', 'clear_traffic', 'get_drilldown_stats']
         params: ['traffic_names', 'ports']
         desc: |
          - IxiaClient
@@ -49,6 +49,7 @@
             start_traffic - [traffic_names]
             stop_traffic  - [traffic_names]
             get_stats - [traffic_names]
+            get_drilldown_stats - [traffic_names]
             clear_stats - [traffic_names]
             clear_traffic - [traffic_names]
       - name: protocol

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client.py
@@ -88,7 +88,7 @@ class IxnetworkIxiaClient(TestLibObject):
         if command in ['load_config', 'save_config']:
             return self.format_config(command, *argv, **kwarg)
         
-        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats', 'clear_traffic']:
+        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats', 'clear_traffic', 'get_drilldown_stats']:
             return self.format_traffic_item(command, *argv, **kwarg)
         
         if command in ['start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats', 'clear_protocol_stats']:
@@ -110,7 +110,7 @@ class IxnetworkIxiaClient(TestLibObject):
         if command in ['load_config', 'save_config']:
             return self.run_config(device_obj, command, *argv, **kwarg)
         
-        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats', 'clear_traffic']:
+        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats', 'clear_traffic', 'get_drilldown_stats']:
             return self.run_traffic_item(device_obj, command, *argv, **kwarg)
         
         if command in ['start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats', 'clear_protocol_stats']:
@@ -133,7 +133,7 @@ class IxnetworkIxiaClient(TestLibObject):
         if command in ['load_config', 'save_config']:
             return self.parse_config(command, output, *argv, **kwarg)
         
-        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats', 'clear_traffic']:
+        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats', 'clear_traffic', 'get_drilldown_stats']:
             return self.parse_traffic_item(command, output, *argv, **kwarg)
         
         if command in ['start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats', 'clear_protocol_stats']:

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -205,6 +205,27 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
         return command
 
     @staticmethod
+    def __configure_egress_tracking(ti, pkt_data):
+        if "egress_track_by" not in pkt_data:
+            return
+        ti.EgressEnabled = True
+        track_by = pkt_data["egress_track_by"]
+        if type(track_by) is list:
+            track_by = "".join(track_by)
+        if "vlan" in track_by:
+            tracker = ti.EgressTracking.add()
+            if "vlan_4k" in track_by:
+                tracker.Offset = "Outer VLAN ID (12 bits)"  # vid 0..4095
+            else:
+                tracker.Offset = "Outer VLAN ID (4 bits)"  # vid 0..15
+        if "pcp" in track_by:
+            tracker = ti.EgressTracking.add()
+            tracker.Offset = "Outer VLAN Priority (3 bits)"  # pcp 0..7
+        if "dscp" in track_by:
+            tracker = ti.EgressTracking.add()
+            tracker.Offset = "IPv4 DSCP (6 bits)"  # dscp 0..63
+
+    @staticmethod
     def __parse_multivalue(value):
         if not "type" in value:
             raise KeyError(f"Value type is mandatory {value}")
@@ -323,6 +344,8 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             IxnetworkIxiaClientImpl.tis.append(ti)
             track_by = {"trackingenabled0", "sourceDestValuePair0"}
             ti.Enabled = True
+            self.__configure_egress_tracking(ti, pkt_data)
+
             for ep in range(ep_count):
                 config_element = ti.ConfigElement.find(EndpointSetId=ep + 1)
                 # set the rate
@@ -402,6 +425,8 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             track_by = {"trackingenabled0", "sourceDestValuePair0"}
             ti.Enabled = True
             ti.BiDirectional = pkt_data.get("bi_directional", False)
+            self.__configure_egress_tracking(ti, pkt_data)
+
             for ep in range(ep_count):
                 config_element = ti.ConfigElement.find(EndpointSetId=ep + 1)
                 # set the rate
@@ -428,6 +453,7 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
            start_traffic - [traffic_names]
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
+           get_drilldown_stats - [traffic_names]
            clear_stats - [traffic_names]
 
         """
@@ -471,6 +497,17 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             stats = SVA(IxnetworkIxiaClientImpl.ixnet, stats_type)
             # device.applog.info(stats)
             return 0, stats
+        elif command == "get_drilldown_stats":
+            UDS = "User Defined Statistics"
+            param = kwarg["params"][0]
+            row = param["row"]
+            view = IxnetworkIxiaClientImpl.ixnet.Statistics.View.find(Caption=row._view_name)
+            view.DoDrillDownByOption(row._index + 1 if row._index != -1 else 1, param["group_by"])
+            uds_view = IxnetworkIxiaClientImpl.ixnet.Statistics.View.find(Caption=UDS)
+            if param.get("num_of_rows"):
+                uds_view.Page.EgressPageSize = int(param["num_of_rows"])
+            uds_view.Enabled = True  # have to enable uds view every time it is changed
+            return self.run_traffic_item(device, "get_stats", params=[{"stats_type": UDS}])
         elif command == "clear_stats":
             device.applog.info("Clear Stats")
             IxnetworkIxiaClientImpl.ixnet.ClearStats()

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/traffic_gen.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/traffic_gen.py
@@ -18,6 +18,7 @@ class TrafficGen(TestLibObject):
             start_traffic - [traffic_names]
             stop_traffic  - [traffic_names]
             get_stats - [traffic_names]
+            get_drilldown_stats - [traffic_names]
             clear_stats - [traffic_names]
             start_protocols - [protocols]
             stop_protocols - [protocols]
@@ -179,6 +180,7 @@ class TrafficGen(TestLibObject):
            start_traffic - [traffic_names]
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
+           get_drilldown_stats - [traffic_names]
            clear_stats - [traffic_names]
            clear_traffic - [traffic_names]
         
@@ -205,6 +207,7 @@ class TrafficGen(TestLibObject):
            start_traffic - [traffic_names]
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
+           get_drilldown_stats - [traffic_names]
            clear_stats - [traffic_names]
            clear_traffic - [traffic_names]
         
@@ -231,6 +234,7 @@ class TrafficGen(TestLibObject):
            start_traffic - [traffic_names]
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
+           get_drilldown_stats - [traffic_names]
            clear_stats - [traffic_names]
            clear_traffic - [traffic_names]
         
@@ -257,6 +261,7 @@ class TrafficGen(TestLibObject):
            start_traffic - [traffic_names]
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
+           get_drilldown_stats - [traffic_names]
            clear_stats - [traffic_names]
            clear_traffic - [traffic_names]
         
@@ -283,6 +288,7 @@ class TrafficGen(TestLibObject):
            start_traffic - [traffic_names]
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
+           get_drilldown_stats - [traffic_names]
            clear_stats - [traffic_names]
            clear_traffic - [traffic_names]
         
@@ -472,8 +478,37 @@ class TrafficGen(TestLibObject):
            start_traffic - [traffic_names]
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
+           get_drilldown_stats - [traffic_names]
            clear_stats - [traffic_names]
            clear_traffic - [traffic_names]
         
         """
         return await TrafficGen._run_command("clear_traffic", *argv, **kwarg)
+        
+    async def get_drilldown_stats(*argv, **kwarg):
+        """
+        Platforms: ['ixnetwork']
+        Usage:
+        TrafficGen.get_drilldown_stats(
+            input_data = [{
+                # device 1
+                'dev1' : [{
+                    # command 1
+                        'traffic_names':'string_list',
+                        'ports':'string_list',
+                }],
+            }],
+        )
+        Description:
+        - IxiaClient
+           set_traffic - [traffic_names], ports
+           start_traffic - [traffic_names]
+           stop_traffic  - [traffic_names]
+           get_stats - [traffic_names]
+           get_drilldown_stats - [traffic_names]
+           clear_stats - [traffic_names]
+           clear_traffic - [traffic_names]
+        
+        """
+        return await TrafficGen._run_command("get_drilldown_stats", *argv, **kwarg)
+        


### PR DESCRIPTION
Add ability to get egress stats by enabling egress tracking.

Currently supported tracking fields:
- `vlan` - vlan id 0..15
- `vlan_4k` - vlan id 0..4095
- `pcp` - vlan priority 0..7
- `dscp` - ipv4 dscp (precedence + tos) 0..63

Usage:
```python
streams = {
    "stream with egress tracking": {
        "type": "ethernet",
        "vlanID": 10,
        "egress_track_by": ["vlan", "pcp"],
    },
}

await tgen_utils_setup_streams(tgen_dev, None, streams)

await tgen_utils_start_traffic(tgen_dev)
await asyncio.sleep(traffic_duration)
await tgen_utils_stop_traffic(tgen_dev)

stats = await tgen_utils_get_traffic_stats(tgen_dev, "Traffic Item Statistics")
for row in stats.Rows:
    egress_stats = await tgen_utils_get_egress_stats(tgen_dev, row)
    for e_row in egress_stats:
        if e_row["Traffic Item"]:  # first row
            tx = int(e_row["Tx Frames"])
            continue

        rx = int(e_row["Rx Frames"])
        vlan = int(e_row["Egress Tracking 1"])
        prio = int(e_row["Egress Tracking 2"])

        assert rx == tx
        assert vlan == 10
        assert prio == 0
"""
INFO:DENT:[Ixia Traffic Generator] Getting Stats
INFO:DENT:[Ixia Traffic Generator] Traffic Item stream with egress tracking Tx 6581 Rx 6581 Loss 0.000
INFO:DENT:[Ixia Traffic Generator] Egress Tracking 1: Ethernet:Outer VLAN ID (4 bits) at offset 124
INFO:DENT:[Ixia Traffic Generator] Egress Tracking 2: Ethernet:Outer VLAN Priority (3 bits) at offset 112
INFO:DENT:[Ixia Traffic Generator] Vlan Id: 0, Vlan Priority: 0 | Rx 3291
INFO:DENT:[Ixia Traffic Generator] Vlan Id: 10, Vlan Priority: 0 | Rx 3290
INFO:DENT:[Ixia Traffic Generator] Getting Stats
INFO:DENT:[Ixia Traffic Generator] Traffic Item stream with egress tracking #1 Tx 6581 Rx 6581 Loss 0.000
INFO:DENT:[Ixia Traffic Generator] Egress Tracking 1: Ethernet:Outer VLAN ID (4 bits) at offset 124
INFO:DENT:[Ixia Traffic Generator] Egress Tracking 2: Ethernet:Outer VLAN Priority (3 bits) at offset 112
INFO:DENT:[Ixia Traffic Generator] Vlan Id: 0, Vlan Priority: 0 | Rx 3291
INFO:DENT:[Ixia Traffic Generator] Vlan Id: 10, Vlan Priority: 0 | Rx 3290
"""
```

Resolves: https://github.com/dentproject/testing/issues/118

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>