### PR TITLE
Fix IPv4 fixture and fix assert message

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/conftest.py
@@ -7,7 +7,7 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
 )
 
 
-@pytest_asyncio.fixture(autouse=True)
+@pytest_asyncio.fixture()
 async def enable_ipv4_forwarding(testbed):
     tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
     if not tgen_dev or not dent_devices:

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_addr.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_addr.py
@@ -16,7 +16,7 @@ from dent_os_testbed.utils.test_utils.tb_utils import (
 
 pytestmark = [
     pytest.mark.suite_functional_ipv4,
-    pytest.mark.usefixtures("cleanup_ip_addrs", "cleanup_tgen"),
+    pytest.mark.usefixtures("cleanup_ip_addrs", "cleanup_tgen", "enable_ipv4_forwarding"),
     pytest.mark.asyncio,
 ]
 

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_class_x_discarded.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_class_x_discarded.py
@@ -17,7 +17,7 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
 
 pytestmark = [
     pytest.mark.suite_functional_ipv4,
-    pytest.mark.usefixtures("cleanup_ip_addrs", "cleanup_tgen"),
+    pytest.mark.usefixtures("cleanup_ip_addrs", "cleanup_tgen", "enable_ipv4_forwarding"),
     pytest.mark.asyncio,
 ]
 

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_en_dis_fwd.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_en_dis_fwd.py
@@ -18,7 +18,7 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
 
 pytestmark = [
     pytest.mark.suite_functional_ipv4,
-    pytest.mark.usefixtures("cleanup_ip_addrs", "cleanup_tgen"),
+    pytest.mark.usefixtures("cleanup_ip_addrs", "cleanup_tgen", "enable_ipv4_forwarding"),
     pytest.mark.asyncio,
 ]
 

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_routing.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_routing.py
@@ -22,7 +22,7 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
 
 pytestmark = [
     pytest.mark.suite_functional_ipv4,
-    pytest.mark.usefixtures("cleanup_ip_addrs", "cleanup_tgen"),
+    pytest.mark.usefixtures("cleanup_ip_addrs", "cleanup_tgen", "enable_ipv4_forwarding"),
     pytest.mark.asyncio,
 ]
 

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
@@ -407,7 +407,7 @@ async def tgen_utils_setup_streams(device, config_file_name, streams, force_upda
                 input_data=[{device.host_name: [{"name": s, "pkt_data": streams[s]}]}]
             )
             device.applog.info(out)
-            assert out[0][device.host_name]["rc"] == 0, "Setting tgen traffic failed.\n{out}"
+            assert out[0][device.host_name]["rc"] == 0, f"Setting tgen traffic failed.\n{out}"
         device.applog.info(f"Saving Tgen config file {config_file_name}")
         out = await TrafficGen.save_config(
             input_data=[{device.host_name: [{"config_file_name": config_file_name}]}]


### PR DESCRIPTION
Remove autouse from ipv4 fixture.
Add missing f to f-string in assert.

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>