### PR TITLE
Update Bridging tests

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_ageing.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_ageing.py
@@ -1,8 +1,8 @@
 import pytest
 import asyncio
 
-from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.bridge.bridge_link import BridgeLink
+from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.ip.ip_link import IpLink
 
 from dent_os_testbed.utils.test_utils.tgen_utils import (
@@ -11,9 +11,9 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_setup_streams,
     tgen_utils_start_traffic,
     tgen_utils_stop_traffic,
+    tgen_utils_get_loss,
     tgen_utils_dev_groups_from_config,
     tgen_utils_traffic_generator_connect,
-    tgen_utils_get_loss
 )
 
 pytestmark = [
@@ -57,20 +57,17 @@ async def test_bridging_ageing_refresh(testbed):
     out = await IpLink.add(
         input_data=[{device_host_name: [
             {"device": bridge, "type": "bridge"}]}])
-    err_msg = f"Verify that bridge created.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge created.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
             {"device": bridge, "operstate": "up"}]}])
-    err_msg = f"Verify that bridge set to 'UP' state.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge set to 'UP' state.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
             {"device": bridge, "ageing_time": ageing_time*100, "type": "bridge"}]}])
-    err_msg = f"Verify that ageing time set to '40'.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that ageing time set to '40'.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
@@ -85,7 +82,7 @@ async def test_bridging_ageing_refresh(testbed):
     assert out[0][device_host_name]["rc"] == 0, err_msg
 
     address_map = (
-        #swp port, tg port,     tg ip,      gw        plen
+        # swp port, tg port,    tg ip,      gw        plen
         (ports[0], tg_ports[0], "1.1.1.2", "1.1.1.1", 24),
         (ports[1], tg_ports[1], "2.2.2.2", "2.2.2.1", 24)
     )
@@ -117,13 +114,14 @@ async def test_bridging_ageing_refresh(testbed):
     # check the traffic stats
     stats = await tgen_utils_get_traffic_stats(tgen_dev, "Traffic Item Statistics")
     for row in stats.Rows:
-        assert float(row["Loss %"]) == 0.000, f'Failed>Loss percent: {row["Loss %"]}'
+        assert tgen_utils_get_loss(row) == 0.000, \
+            f"Verify that traffic from {row['Tx Port']} to {row['Rx Port']} forwarded.\n{out}"
 
     await asyncio.sleep(0.75*ageing_time)
 
     out = await BridgeFdb.show(input_data=[{device_host_name: [{"options": "-j"}]}],
                                parse_output=True)
-    assert out[0][device_host_name]["rc"] == 0, "Failed to get fdb entry.\n"
+    assert out[0][device_host_name]["rc"] == 0, f"Failed to get fdb entry.\n"
 
     fdb_entries = out[0][device_host_name]["parsed_output"]
     learned_macs = [en["mac"] for en in fdb_entries if "mac" in en]
@@ -136,13 +134,13 @@ async def test_bridging_ageing_refresh(testbed):
     stats = await tgen_utils_get_traffic_stats(tgen_dev, "Traffic Item Statistics")
     for row in stats.Rows:
         assert tgen_utils_get_loss(row) == 0.000, \
-        f"Verify that traffic from {row['Tx Port']} to {row['Rx Port']} forwarded.\n{out}"
+            f"Verify that traffic from {row['Tx Port']} to {row['Rx Port']} forwarded.\n{out}"
 
     await asyncio.sleep(0.9*ageing_time)
 
     out = await BridgeFdb.show(input_data=[{device_host_name: [{"options": "-j"}]}],
                                parse_output=True)
-    assert out[0][device_host_name]["rc"] == 0, "Failed to get fdb entry.\n"
+    assert out[0][device_host_name]["rc"] == 0, f"Failed to get fdb entry.\n"
 
     fdb_entries = out[0][device_host_name]["parsed_output"]
     learned_macs = [en["mac"] for en in fdb_entries if "mac" in en]
@@ -156,11 +154,12 @@ async def test_bridging_ageing_refresh(testbed):
     # check the traffic stats
     stats = await tgen_utils_get_traffic_stats(tgen_dev, "Traffic Item Statistics")
     for row in stats.Rows:
-        assert float(row["Loss %"]) == 0.000, f'Failed>Loss percent: {row["Loss %"]}'
+        assert tgen_utils_get_loss(row) == 0.000, \
+            f"Verify that traffic from {row['Tx Port']} to {row['Rx Port']} forwarded.\n{out}"
 
     out = await BridgeFdb.show(input_data=[{device_host_name: [{"options": "-j"}]}],
                                parse_output=True)
-    assert out[0][device_host_name]["rc"] == 0, "Failed to get fdb entry.\n"
+    assert out[0][device_host_name]["rc"] == 0, f"Failed to get fdb entry.\n"
 
     fdb_entries = out[0][device_host_name]["parsed_output"]
     learned_macs = [en["mac"] for en in fdb_entries if "mac" in en]
@@ -203,20 +202,17 @@ async def test_bridging_ageing_under_continue(testbed):
     out = await IpLink.add(
        input_data=[{device_host_name: [
            {"device": bridge, "type": "bridge"}]}])
-    err_msg = f"Verify that bridge created.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge created.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
             {"device": bridge, "operstate": "up"}]}])
-    err_msg = f"Verify that bridge set to 'UP' state.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge set to 'UP' state.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
             {"device": bridge, "ageing_time": ageing_time*100, "type": "bridge"}]}])
-    err_msg = f"Verify that ageing time set to '10'.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that ageing time set to '10'.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
@@ -231,7 +227,7 @@ async def test_bridging_ageing_under_continue(testbed):
     assert out[0][device_host_name]["rc"] == 0, err_msg
 
     address_map = (
-        #swp port, tg port,     tg ip,     gw,        plen
+        # swp port, tg port,    tg ip,     gw,        plen
         (ports[0], tg_ports[0], "1.1.1.2", "1.1.1.1", 24),
         (ports[1], tg_ports[1], "2.2.2.2", "2.2.2.1", 24),
         (ports[2], tg_ports[2], "3.3.3.2", "3.3.3.1", 24),
@@ -271,7 +267,7 @@ async def test_bridging_ageing_under_continue(testbed):
 
     out = await BridgeFdb.show(input_data=[{device_host_name: [{"options": "-j"}]}],
                                parse_output=True)
-    assert out[0][device_host_name]["rc"] == 0, "Failed to get fdb entry.\n"
+    assert out[0][device_host_name]["rc"] == 0, f"Failed to get fdb entry.\n"
 
     fdb_entries = out[0][device_host_name]["parsed_output"]
     learned_macs = [en["mac"] for en in fdb_entries if "mac" in en]

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_backward_forwarding.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_backward_forwarding.py
@@ -1,8 +1,8 @@
 import pytest
 import asyncio
 
-from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.bridge.bridge_link import BridgeLink
+from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.ip.ip_link import IpLink
 
 from dent_os_testbed.utils.test_utils.tgen_utils import (
@@ -11,9 +11,9 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_setup_streams,
     tgen_utils_start_traffic,
     tgen_utils_stop_traffic,
+    tgen_utils_get_loss,
     tgen_utils_dev_groups_from_config,
     tgen_utils_traffic_generator_connect,
-    tgen_utils_get_loss
 )
 
 pytestmark = [
@@ -79,7 +79,7 @@ async def test_bridging_backward_forwarding(testbed):
     assert out[0][device_host_name]["rc"] == 0, err_msg
 
     address_map = (
-        # swp port, tg port,     tg ip,     gw,        plen
+        # swp port, tg port,    tg ip,     gw,        plen
         (ports[0], tg_ports[0], "1.1.1.2", "1.1.1.1", 24),
         (ports[0], tg_ports[0], "1.1.1.3", "1.1.1.1", 24),
     )
@@ -120,11 +120,11 @@ async def test_bridging_backward_forwarding(testbed):
     stats = await tgen_utils_get_traffic_stats(tgen_dev, "Traffic Item Statistics")
     for row in stats.Rows:
         assert tgen_utils_get_loss(row) == 100.000, \
-        f"Verify that traffic from {row['Tx Port']} to {row['Rx Port']} not forwarded.\n{out}"
+            f"Verify that traffic from {row['Tx Port']} to {row['Rx Port']} not forwarded.\n{out}"
 
     out = await BridgeFdb.show(input_data=[{device_host_name: [{"options": "-j"}]}],
                                parse_output=True)
-    assert out[0][device_host_name]["rc"] == 0, "Failed to get fdb entry.\n"
+    assert out[0][device_host_name]["rc"] == 0, f"Failed to get fdb entry.\n"
 
     fdb_entries = out[0][device_host_name]["parsed_output"]
     learned_macs = [en["mac"] for en in fdb_entries if "mac" in en]

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_learning_address.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_learning_address.py
@@ -1,8 +1,8 @@
 import pytest
 import asyncio
 
-from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.bridge.bridge_link import BridgeLink
+from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.ip.ip_link import IpLink
 
 from dent_os_testbed.utils.test_utils.tgen_utils import (
@@ -10,16 +10,17 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_traffic_stats,
     tgen_utils_setup_streams,
     tgen_utils_start_traffic,
-    tgen_utils_stop_protocols,
     tgen_utils_stop_traffic,
     tgen_utils_dev_groups_from_config,
     tgen_utils_traffic_generator_connect
 )
 
-pytestmark = pytest.mark.suite_functional_bridging
+pytestmark = [
+    pytest.mark.suite_functional_bridging,
+    pytest.mark.asyncio,
+    pytest.mark.usefixtures("cleanup_bridges", "cleanup_tgen")
+]
 
-
-@pytest.mark.asyncio
 async def test_bridging_learning_address(testbed):
     """
     Test Name: test_bridging_learning_address
@@ -33,16 +34,16 @@ async def test_bridging_learning_address(testbed):
     4.  Set entities swp1, swp2, swp3, swp4 UP state.
     5.  Set ports swp1, swp2, swp3, swp4 learning ON.
     6.  Set ports swp1, swp2, swp3, swp4 flood OFF.
-    7.  Send traffic to swp1, swp2, swp3, swp4 with source macs 
-        aa:bb:cc:dd:ee:11 aa:bb:cc:dd:ee:12 
+    7.  Send traffic to swp1, swp2, swp3, swp4 with source macs
+        aa:bb:cc:dd:ee:11 aa:bb:cc:dd:ee:12
         aa:bb:cc:dd:ee:13 aa:bb:cc:dd:ee:14 accordingly.
-    8.  Verify that address have been learned.
+    8.  Verify that addresses have been learned.
     """
 
     bridge = "br0"
     tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
     if not tgen_dev or not dent_devices:
-        print.error("The testbed does not have enough dent with tgen connections")
+        print("The testbed does not have enough dent with tgen connections")
         return
     dent_dev = dent_devices[0]
     device_host_name = dent_dev.host_name
@@ -53,15 +54,13 @@ async def test_bridging_learning_address(testbed):
     out = await IpLink.add(
         input_data=[{device_host_name: [
             {"device": bridge, "type": "bridge"}]}])
-    err_msg = f"Verify that bridge created.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge created.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
             {"device": bridge, "operstate": "up"}]}])
-    err_msg = f"Verify that bridge set to 'UP' state.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
-    
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge set to 'UP' state.\n{out}"
+
     out = await IpLink.set(
         input_data=[{device_host_name: [
             {"device": port, "master": bridge, "operstate": "up"} for port in ports]}])
@@ -75,7 +74,7 @@ async def test_bridging_learning_address(testbed):
     assert out[0][device_host_name]["rc"] == 0, err_msg
 
     address_map = (
-        #swp port, tg port,     tg ip,     gw,        plen
+        # swp port, tg port,    tg ip,     gw,        plen
         (ports[0], tg_ports[0], "1.1.1.2", "1.1.1.1", 24),
         (ports[1], tg_ports[1], "2.2.2.2", "2.2.2.1", 24),
         (ports[2], tg_ports[2], "3.3.3.2", "3.3.3.1", 24),
@@ -88,7 +87,7 @@ async def test_bridging_learning_address(testbed):
     )
 
     await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
-    
+
     list_macs = ["aa:bb:cc:dd:ee:11", "aa:bb:cc:dd:ee:12",
                  "aa:bb:cc:dd:ee:13", "aa:bb:cc:dd:ee:14"]
 
@@ -123,5 +122,3 @@ async def test_bridging_learning_address(testbed):
     for mac in list_macs:
         err_msg = f"Verify that source macs have been learned.\n"
         assert mac in learned_macs, err_msg
-
-    await tgen_utils_stop_protocols(tgen_dev)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_learning_illegal_address.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_learning_illegal_address.py
@@ -1,8 +1,8 @@
 import pytest
 import asyncio
 
-from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.bridge.bridge_link import BridgeLink
+from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.ip.ip_link import IpLink
 
 from dent_os_testbed.utils.test_utils.tgen_utils import (
@@ -11,9 +11,9 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_setup_streams,
     tgen_utils_start_traffic,
     tgen_utils_stop_traffic,
+    tgen_utils_get_loss,
     tgen_utils_dev_groups_from_config,
     tgen_utils_traffic_generator_connect,
-    tgen_utils_get_loss
 )
 
 pytestmark = [
@@ -35,8 +35,8 @@ async def test_bridging_learning_illegal_address(testbed):
     4.  Set bridge br0 admin state UP.
     5.  Set ports swp1, swp2, swp3, swp4 learning ON.
     6.  Set ports swp1, swp2, swp3, swp4 flood OFF.
-    7.  Send traffic by TG with illegal address.
-    8.  Verify that illegal address haven't been learned.
+    7.  Send traffic by TG with illegal addresses.
+    8.  Verify that illegal addresses haven't been learned.
     """
 
     bridge = "br0"
@@ -53,14 +53,12 @@ async def test_bridging_learning_illegal_address(testbed):
     out = await IpLink.add(
         input_data=[{device_host_name: [
             {"device": bridge, "type": "bridge"}]}])
-    err_msg = f"Verify that bridge created.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge created.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
             {"device": bridge, "operstate": "up"}]}])
-    err_msg = f"Verify that bridge set to 'UP' state.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge set to 'UP' state.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
@@ -75,7 +73,7 @@ async def test_bridging_learning_illegal_address(testbed):
     assert out[0][device_host_name]["rc"] == 0, err_msg
 
     address_map = (
-        #swp port, tg port,     tg ip,     gw,        plen
+        # swp port, tg port,    tg ip,     gw,        plen
         (ports[0], tg_ports[0], "1.1.1.2", "1.1.1.1", 24),
         (ports[1], tg_ports[1], "2.2.2.2", "2.2.2.1", 24),
         (ports[2], tg_ports[2], "3.3.3.2", "3.3.3.1", 24),

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_mac_table_size.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_mac_table_size.py
@@ -10,9 +10,9 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_setup_streams,
     tgen_utils_start_traffic,
     tgen_utils_stop_traffic,
+    tgen_utils_get_loss,
     tgen_utils_dev_groups_from_config,
     tgen_utils_traffic_generator_connect,
-    tgen_utils_get_loss
 )
 
 pytestmark = [
@@ -106,7 +106,7 @@ async def test_bridging_mac_table_size(testbed):
     await asyncio.sleep(traffic_duration)
     await tgen_utils_stop_traffic(tgen_dev)
 
-    #check the traffic stats
+    # check the traffic stats
     stats = await tgen_utils_get_traffic_stats(tgen_dev, "Traffic Item Statistics")
     for row in stats.Rows:
         loss = tgen_utils_get_loss(row)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_packets_oversize.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_packets_oversize.py
@@ -2,9 +2,9 @@ import pytest
 import asyncio
 
 from dent_os_testbed.lib.bridge.bridge_link import BridgeLink
-from dent_os_testbed.lib.ip.ip_link import IpLink
-from dent_os_testbed.lib.ethtool.ethtool import Ethtool
 from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
+from dent_os_testbed.lib.ethtool.ethtool import Ethtool
+from dent_os_testbed.lib.ip.ip_link import IpLink
 
 from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_dent_devices_with_tgen,
@@ -12,9 +12,9 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_setup_streams,
     tgen_utils_start_traffic,
     tgen_utils_stop_traffic,
+    tgen_utils_get_loss,
     tgen_utils_dev_groups_from_config,
     tgen_utils_traffic_generator_connect,
-    tgen_utils_get_loss
 )
 
 pytestmark = [
@@ -48,8 +48,8 @@ async def test_bridging_packets_oversize(testbed):
     5.  Set ports swp1, swp2, swp3, swp4 learning ON.
     6.  Set ports swp1, swp2, swp3, swp4 flood OFF.
     7.  Set streams frameSize 2000.
-    8.  Send traffic for bridge to learn address.
-    9.  Verify that address haven't been learned due to oversized packet.
+    8.  Send traffic for bridge to learn addresses.
+    9.  Verify that addresses haven't been learned due to oversized packet.
     """
 
     bridge = "br0"
@@ -66,14 +66,12 @@ async def test_bridging_packets_oversize(testbed):
     out = await IpLink.add(
         input_data=[{device_host_name: [
             {"device": bridge, "type": "bridge"}]}])
-    err_msg = f"Verify that bridge created.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge created.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
             {"device": bridge, "operstate": "up"}]}])
-    err_msg = f"Verify that bridge set to 'UP' state.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge set to 'UP' state.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
@@ -88,7 +86,7 @@ async def test_bridging_packets_oversize(testbed):
     assert out[0][device_host_name]["rc"] == 0, err_msg
 
     address_map = (
-        #swp port, tg port,     tg ip,     gw,        plen
+        # swp port, tg port,    tg ip,     gw,        plen
         (ports[0], tg_ports[0], "1.1.1.2", "1.1.1.1", 24),
         (ports[1], tg_ports[1], "2.2.2.2", "2.2.2.1", 24),
         (ports[2], tg_ports[2], "3.3.3.2", "3.3.3.1", 24),

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_packets_undersize.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_packets_undersize.py
@@ -2,9 +2,9 @@ import pytest
 import asyncio
 
 from dent_os_testbed.lib.bridge.bridge_link import BridgeLink
-from dent_os_testbed.lib.ip.ip_link import IpLink
-from dent_os_testbed.lib.ethtool.ethtool import Ethtool
 from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
+from dent_os_testbed.lib.ethtool.ethtool import Ethtool
+from dent_os_testbed.lib.ip.ip_link import IpLink
 
 from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_dent_devices_with_tgen,
@@ -12,9 +12,9 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_setup_streams,
     tgen_utils_start_traffic,
     tgen_utils_stop_traffic,
+    tgen_utils_get_loss,
     tgen_utils_dev_groups_from_config,
     tgen_utils_traffic_generator_connect,
-    tgen_utils_get_loss
 )
 
 pytestmark = [
@@ -48,14 +48,14 @@ async def test_bridging_packets_undersize(testbed):
     5.  Set ports swp1, swp2, swp3, swp4 learning ON.
     6.  Set ports swp1, swp2, swp3, swp4 flood OFF.
     7.  Set streams frameSize 48.
-    8.  Send traffic for bridge to learn address.
-    9.  Verify that address haven't been learned due to undersized packet.
+    8.  Send traffic for bridge to learn addresses.
+    9.  Verify that addresses haven't been learned due to undersized packet.
     """
 
     bridge = "br0"
     tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
     if not tgen_dev or not dent_devices:
-        print.error("The testbed does not have enough dent with tgen connections")
+        print("The testbed does not have enough dent with tgen connections")
         return
     dent_dev = dent_devices[0]
     device_host_name = dent_dev.host_name
@@ -86,7 +86,7 @@ async def test_bridging_packets_undersize(testbed):
     assert out[0][device_host_name]["rc"] == 0, err_msg
 
     address_map = (
-        #swp port, tg port,     tg ip,     gw,        plen
+        # swp port, tg port,    tg ip,     gw,        plen
         (ports[0], tg_ports[0], "1.1.1.2", "1.1.1.1", 24),
         (ports[1], tg_ports[1], "2.2.2.2", "2.2.2.1", 24),
         (ports[2], tg_ports[2], "3.3.3.2", "3.3.3.1", 24),

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_remove_restore_from_vlan.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_remove_restore_from_vlan.py
@@ -1,9 +1,9 @@
 import pytest
 import asyncio
 
-from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.bridge.bridge_link import BridgeLink
 from dent_os_testbed.lib.bridge.bridge_vlan import BridgeVlan
+from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.ip.ip_link import IpLink
 
 from dent_os_testbed.utils.test_utils.tgen_utils import (
@@ -12,9 +12,9 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_setup_streams,
     tgen_utils_start_traffic,
     tgen_utils_stop_traffic,
+    tgen_utils_get_loss,
     tgen_utils_dev_groups_from_config,
     tgen_utils_traffic_generator_connect,
-    tgen_utils_get_loss
 )
 
 pytestmark = [
@@ -48,8 +48,7 @@ async def test_bridging_remove_restore_from_vlan(testbed):
     bridge = "br0"
     tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 3)
     if not tgen_dev or not dent_devices:
-        print.error(
-            "The testbed does not have enough dent with tgen connections")
+        print("The testbed does not have enough dent with tgen connections")
         return
     dent_dev = dent_devices[0]
     device_host_name = dent_dev.host_name
@@ -96,7 +95,7 @@ async def test_bridging_remove_restore_from_vlan(testbed):
 
     out = await BridgeFdb.show(input_data=[{device_host_name: [{"options": "-j"}]}],
                                parse_output=True)
-    assert out[0][device_host_name]["rc"] == 0, "Failed to get fdb entry.\n"
+    assert out[0][device_host_name]["rc"] == 0, f"Failed to get fdb entry.\n"
 
     fdb_entries = out[0][device_host_name]["parsed_output"]
     learned_macs = [en["mac"] for en in fdb_entries if "mac" in en]

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_static_entries.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_static_entries.py
@@ -1,8 +1,8 @@
 import pytest
 import asyncio
 
-from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.bridge.bridge_link import BridgeLink
+from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.ip.ip_link import IpLink
 
 from dent_os_testbed.utils.test_utils.tgen_utils import (
@@ -37,7 +37,7 @@ async def test_bridging_static_entries(testbed):
     6.  Set ports swp1, swp2, swp3, swp4 flood OFF.
     7.  Adding FDB static entries for ports swp1, swp2, swp3, swp4.
     8.  Send traffic with matching destination macs.
-    9.  Verify that address have been forwarded.
+    9.  Verify that addresses have been forwarded.
     """
 
     bridge = "br0"
@@ -54,14 +54,12 @@ async def test_bridging_static_entries(testbed):
     out = await IpLink.add(
         input_data=[{device_host_name: [
             {"device": bridge, "type": "bridge"}]}])
-    err_msg = f"Verify that bridge created.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge created.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
             {"device": bridge, "operstate": "up"}]}])
-    err_msg = f"Verify that bridge set to 'UP' state.\n{out}"
-    assert out[0][device_host_name]["rc"] == 0, err_msg
+    assert out[0][device_host_name]["rc"] == 0, f"Verify that bridge set to 'UP' state.\n{out}"
 
     out = await IpLink.set(
         input_data=[{device_host_name: [
@@ -85,7 +83,7 @@ async def test_bridging_static_entries(testbed):
     assert out[0][device_host_name]["rc"] == 0, f"Verify that FDB static entries added.\n{out}"
 
     address_map = (
-        #swp port, tg port,     tg ip,     gw,        plen
+        # swp port, tg port,    tg ip,     gw,        plen
         (ports[0], tg_ports[0], "1.1.1.2", "1.1.1.1", 24),
         (ports[1], tg_ports[1], "2.2.2.2", "2.2.2.1", 24),
         (ports[2], tg_ports[2], "3.3.3.2", "3.3.3.1", 24),
@@ -122,6 +120,5 @@ async def test_bridging_static_entries(testbed):
     # check the traffic stats
     stats = await tgen_utils_get_traffic_stats(tgen_dev, "Traffic Item Statistics")
     for row in stats.Rows:
-        assert float(row["Loss %"]) == 0.000, f'Failed>Loss percent: {row["Loss %"]}'
         assert tgen_utils_get_loss(row) == 0.000, \
-        f"Verify that traffic from {row['Tx Port']} to {row['Rx Port']} forwarded.\n{out}"
+            f"Verify that traffic from {row['Tx Port']} to {row['Rx Port']} forwarded.\n{out}"

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_traffic_from_nomaster.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/bridging/test_bridging_traffic_from_nomaster.py
@@ -1,8 +1,8 @@
 import pytest
 import asyncio
 
-from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.bridge.bridge_link import BridgeLink
+from dent_os_testbed.lib.bridge.bridge_fdb import BridgeFdb
 from dent_os_testbed.lib.ip.ip_link import IpLink
 
 from dent_os_testbed.utils.test_utils.tgen_utils import (


### PR DESCRIPTION
Update all Bridging tests.
- Used cleanup fixtures between tests
- Fixed typo errors
- Fixed call print
- Fixed f-strings
- Removed unnecessary spaces
- Corrected grammatical errors

