### PR TITLE
add functionality which clear traffic items

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
@@ -486,6 +486,10 @@ async def tgen_utils_clear_traffic_stats(device):
     device.applog.info(out)
     # assert out[0][device.host_name]["rc"] == 0
 
+async def tgen_utils_clear_traffic_items(device):
+    device.applog.info(f"Removing Traffic Items from the device: {device.host_name}")
+    out = await TrafficGen.clear_traffic(input_data=[{device.host_name: [{}]}])
+    device.applog.info(out)
 
 async def tgen_utils_stop_protocols(device):
     device.applog.info("Stopping Protocols")

--- a/DentOS_Framework/DentOsTestbedLib/gen/model/dent/traffic/traffic.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/dent/traffic/traffic.yaml
@@ -33,7 +33,12 @@
           clear_protocol_stats - [protocols]
           send_ping - [port, dst_ip, src_ip]
           send_arp - [port, src_ip]
-    apis: ['connect', 'disconnect', 'load_config', 'save_config', 'set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats', 'start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats', 'clear_protocol_stats', 'send_arp', 'send_ping']
+          clear_traffic - [traffic_names]
+    apis: ['connect', 'disconnect',
+           'load_config', 'save_config',
+           'set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats',
+           'start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats',
+           'clear_protocol_stats', 'send_arp', 'send_ping', 'clear_traffic']
     members:
     - name: client_addr
       type: ip_addr_t

--- a/DentOS_Framework/DentOsTestbedLib/gen/model/traffic/ixia/ixia.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/traffic/ixia/ixia.yaml
@@ -21,6 +21,7 @@
           clear_protocol_stats - [protocols]
           send_ping - [port, dst_ip, src_ip]
           send_arp - [port, src_ip]
+          clear_traffic - [traffic_names]
      implements: "dent:traffic:traffic_gen"
      platforms: ['ixnetwork']
      commands:
@@ -40,7 +41,7 @@
             save_config - config_file_name
       - name: traffic_item
         apis: ['set_traffic', 'start_traffic', 'stop_traffic',
-               'get_stats', 'clear_stats']
+               'get_stats', 'clear_stats', 'clear_traffic']
         params: ['traffic_names', 'ports']
         desc: |
          - IxiaClient
@@ -49,6 +50,7 @@
             stop_traffic  - [traffic_names]
             get_stats - [traffic_names]
             clear_stats - [traffic_names]
+            clear_traffic - [traffic_names]
       - name: protocol
         apis: ['start_protocols', 'stop_protocols', 'set_protocol',
                'get_protocol_stats', 'clear_protocol_stats']

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client.py
@@ -24,6 +24,7 @@ class IxnetworkIxiaClient(TestLibObject):
             clear_protocol_stats - [protocols]
             send_ping - [port, dst_ip, src_ip]
             send_arp - [port, src_ip]
+            clear_traffic - [traffic_names]
         
     """
     def format_connect(self, command, *argv, **kwarg):
@@ -87,7 +88,7 @@ class IxnetworkIxiaClient(TestLibObject):
         if command in ['load_config', 'save_config']:
             return self.format_config(command, *argv, **kwarg)
         
-        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats']:
+        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats', 'clear_traffic']:
             return self.format_traffic_item(command, *argv, **kwarg)
         
         if command in ['start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats', 'clear_protocol_stats']:
@@ -109,7 +110,7 @@ class IxnetworkIxiaClient(TestLibObject):
         if command in ['load_config', 'save_config']:
             return self.run_config(device_obj, command, *argv, **kwarg)
         
-        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats']:
+        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats', 'clear_traffic']:
             return self.run_traffic_item(device_obj, command, *argv, **kwarg)
         
         if command in ['start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats', 'clear_protocol_stats']:
@@ -132,7 +133,7 @@ class IxnetworkIxiaClient(TestLibObject):
         if command in ['load_config', 'save_config']:
             return self.parse_config(command, output, *argv, **kwarg)
         
-        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats']:
+        if command in ['set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats', 'clear_traffic']:
             return self.parse_traffic_item(command, output, *argv, **kwarg)
         
         if command in ['start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats', 'clear_protocol_stats']:

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -462,6 +462,11 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
         elif command == "clear_stats":
             device.applog.info("Clear Stats")
             IxnetworkIxiaClientImpl.ixnet.ClearStats()
+        elif command == "clear_traffic":
+            for traffic_item in IxnetworkIxiaClientImpl.tis:
+                device.applog.info(f"TI to be removed: {traffic_item.Name}")
+                traffic_item.remove()
+            IxnetworkIxiaClientImpl.tis.clear()
         return 0, ""
 
     def parse_traffic_item(self, command, output, *argv, **kwarg):

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/traffic_gen.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/traffic_gen.py
@@ -26,6 +26,7 @@ class TrafficGen(TestLibObject):
             clear_protocol_stats - [protocols]
             send_ping - [port, dst_ip, src_ip]
             send_arp - [port, src_ip]
+            clear_traffic - [traffic_names]
         
     """
     async def _run_command(api, *argv, **kwarg):
@@ -179,6 +180,7 @@ class TrafficGen(TestLibObject):
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
            clear_stats - [traffic_names]
+           clear_traffic - [traffic_names]
         
         """
         return await TrafficGen._run_command("set_traffic", *argv, **kwarg)
@@ -204,6 +206,7 @@ class TrafficGen(TestLibObject):
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
            clear_stats - [traffic_names]
+           clear_traffic - [traffic_names]
         
         """
         return await TrafficGen._run_command("start_traffic", *argv, **kwarg)
@@ -229,6 +232,7 @@ class TrafficGen(TestLibObject):
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
            clear_stats - [traffic_names]
+           clear_traffic - [traffic_names]
         
         """
         return await TrafficGen._run_command("stop_traffic", *argv, **kwarg)
@@ -254,6 +258,7 @@ class TrafficGen(TestLibObject):
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
            clear_stats - [traffic_names]
+           clear_traffic - [traffic_names]
         
         """
         return await TrafficGen._run_command("get_stats", *argv, **kwarg)
@@ -279,6 +284,7 @@ class TrafficGen(TestLibObject):
            stop_traffic  - [traffic_names]
            get_stats - [traffic_names]
            clear_stats - [traffic_names]
+           clear_traffic - [traffic_names]
         
         """
         return await TrafficGen._run_command("clear_stats", *argv, **kwarg)
@@ -446,3 +452,28 @@ class TrafficGen(TestLibObject):
         """
         return await TrafficGen._run_command("send_ping", *argv, **kwarg)
         
+    async def clear_traffic(*argv, **kwarg):
+        """
+        Platforms: ['ixnetwork']
+        Usage:
+        TrafficGen.clear_traffic(
+            input_data = [{
+                # device 1
+                'dev1' : [{
+                    # command 1
+                        'traffic_names':'string_list',
+                        'ports':'string_list',
+                }],
+            }],
+        )
+        Description:
+        - IxiaClient
+           set_traffic - [traffic_names], ports
+           start_traffic - [traffic_names]
+           stop_traffic  - [traffic_names]
+           get_stats - [traffic_names]
+           clear_stats - [traffic_names]
+           clear_traffic - [traffic_names]
+        
+        """
+        return await TrafficGen._run_command("clear_traffic", *argv, **kwarg)


### PR DESCRIPTION
Added functionality which can clear traffic items.

- **Example:**
`await tgen_utils_clear_traffic_items(tgen_dev)`
- **Modified files:**
DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
DentOS_Framework/DentOsTestbedLib/gen/model/dent/traffic/traffic.yaml
DentOS_Framework/DentOsTestbedLib/gen/model/traffic/ixia/ixia.yaml
DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client.py
DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/traffic_gen.py

Resolves: #125 