### PR TITLE
QUAGGA_CONFIG update

### DIFF
--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg1/QUAGGA_CONFIG
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg1/QUAGGA_CONFIG
@@ -8,6 +8,7 @@ no zebra nexthop kernel enable
 !
 router bgp 65511
  bgp router-id 20.20.0.3
+ no bgp ebgp-requires-policy
  neighbor INFRA peer-group
  neighbor INFRA remote-as 65534
  neighbor INFRA timers 3 10

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg2/QUAGGA_CONFIG
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg2/QUAGGA_CONFIG
@@ -8,6 +8,7 @@ no zebra nexthop kernel enable
 !
 router bgp 65511
  bgp router-id 20.20.0.4
+ no bgp ebgp-requires-policy
  neighbor INFRA peer-group
  neighbor INFRA remote-as 65534
  neighbor INFRA timers 3 10

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/dist1/QUAGGA_CONFIG
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/dist1/QUAGGA_CONFIG
@@ -8,6 +8,7 @@ no zebra nexthop kernel enable
 !
 router bgp 65535
  bgp router-id 20.20.0.1
+ no bgp ebgp-requires-policy
  neighbor INFRA peer-group
  neighbor INFRA remote-as 65534
  neighbor INFRA timers 3 10

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra1/QUAGGA_CONFIG
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra1/QUAGGA_CONFIG
@@ -8,6 +8,7 @@ no zebra nexthop kernel enable
 !
 router bgp 65534
  bgp router-id 20.20.0.101
+ no bgp ebgp-requires-policy
  neighbor INFRA peer-group
  neighbor INFRA remote-as 65534
  neighbor INFRA timers 3 10

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra2/QUAGGA_CONFIG
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra2/QUAGGA_CONFIG
@@ -8,6 +8,7 @@ no zebra nexthop kernel enable
 !
 router bgp 65534
  bgp router-id 20.20.0.102
+ no bgp ebgp-requires-policy
  neighbor INFRA peer-group
  neighbor INFRA remote-as 65534
  neighbor INFRA timers 3 10


### PR DESCRIPTION
QUAGGA_CONFIG there is no policy (route-map) defined for peer-group IXIA. 
Due to that it is not able to receive routes In/Out. 
If we add “no bgp ebgp-requires-policy”, it advertises and receives the routes from other peers and traffic flows fine.