### PR TITLE
Fix ACL Scale tests

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/dentv2/acl/scale/test_acl_scale_max_rules.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/dentv2/acl/scale/test_acl_scale_max_rules.py
@@ -320,7 +320,12 @@ async def _test_dentv2_acl_scale_max_rules_helper(
     port = stream_input["dstPort"]
     for ip in ip_src:
         host_name, _, swp = ip.split("_")
-        stream_input["dstPort"] = f"{port}:1:{num_rules_dict[host_name][swp]-1}"
+        stream_input["dstPort"] = {
+            "type": "increment",
+            "start": port,
+            "step": 1,
+            "count": num_rules_dict[host_name][swp] - 1,
+        }
         stream_input["ip_source"] = [ip]
         stream_input["ip_destination"] = ip_dst
         streams[f"{host_name}_tcp_flow_{swp}"] = stream_input.copy()

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/dentv2/acl/scale/test_acl_scale_max_rules_store.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/dentv2/acl/scale/test_acl_scale_max_rules_store.py
@@ -157,7 +157,12 @@ async def test_dentv2_acl_scale_max_rules_store(testbed):
         port = stream_input["dstPort"]
         for ip in ip_src:
             host_name, _, swp = ip.split("_")
-            stream_input["dstPort"] = f"{port}:1:{num_rules_dict[host_name][swp]-1}"
+            stream_input["dstPort"] = {
+                "type": "increment",
+                "start": port,
+                "step": 1,
+                "count": num_rules_dict[host_name][swp] - 1,
+            }
             stream_input["ep_source"] = [f"{host_name}:{swp}"]
             streams[f"{host_name}_tcp_flow_{swp}"] = stream_input.copy()
 


### PR DESCRIPTION
After the introduction of a commit (1d4dc99) that allowed to create traffic items with increment value fields the behavior for specifying src/dst ports has changed.
The port should only be specified as a single value string, or as a dict with a type (increment/decrement/random/list) and type parameters.

No issue is associated with this fix.

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>