### PR TITLE
 F811 redefinition of unused

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,4 @@ repos:
   rev: 6.0.0
   hooks:
   - id: flake8
-    args: ["--max-line-length=201", "--extend-ignore=W605,F401,F402,F523,F524,F541,F601,F632,F811,F821,F841,E701,E722,E741"]
+    args: ["--max-line-length=201", "--extend-ignore=W605,F401,F402,F523,F524,F541,F601,F632,F821,F841,E701,E722,E741"]

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/alpha/switching/test_trunk_port.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/alpha/switching/test_trunk_port.py
@@ -12,7 +12,6 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_dent_devices_with_tgen,
     tgen_utils_get_loss,
     tgen_utils_get_traffic_stats,
-    tgen_utils_get_loss,
     tgen_utils_setup_streams,
     tgen_utils_start_traffic,
     tgen_utils_stop_protocols,

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -4,7 +4,6 @@ import re
 
 from dent_os_testbed.lib.traffic.ixnetwork.ixnetwork_ixia_client import IxnetworkIxiaClient
 from ixnetwork_restpy.assistants.statistics.statviewassistant import StatViewAssistant as SVA
-from ixnetwork_restpy.files import Files
 from ixnetwork_restpy.testplatform.testplatform import TestPlatform
 from ixnetwork_restpy import SessionAssistant, Files
 


### PR DESCRIPTION
- DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/alpha/switching/test_trunk_port.py:10:1: F811 redefinition of unused 'tgen_utils_get_loss' from line 10
- DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py:9:1: F811 redefinition of unused 'Files' from line 7