### PR TITLE
F841 local variable 'parse_cmd_body' is assigned to but never used

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
   rev: 6.0.0
   hooks:
   - id: flake8
-    args: ["--max-line-length=201", "--extend-ignore=F601,F821,F841"]
+    args: ["--max-line-length=201", "--extend-ignore=F601,F821"]
 
 # F601 - https://github.com/dentproject/testing/issues/284
 # F821 - https://github.com/dentproject/testing/issues/278

--- a/DentOS_Framework/DentOsTestbedLib/gen/plugins/test/plugin.py
+++ b/DentOS_Framework/DentOsTestbedLib/gen/plugins/test/plugin.py
@@ -276,7 +276,7 @@ class TestCmdImplPyObject(object):
             parse_cmd_body = tokenize(py_impl_class_common_parse_cmd % cargs)
             methods.append(
                 PyMethod(
-                    'parse_%s' % cmd.name, 'self, command, output, *argv, **kwarg', format_cmd_body, indent=4,
+                    'parse_%s' % cmd.name, 'self, command, output, *argv, **kwarg', parse_cmd_body, indent=4,
                 )
             )
         self._classes.append(


### PR DESCRIPTION
fixes the name of the variable used in the PyMethod