### PR TITLE
Fix pytest_runtest_makereport hook

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/conftest.py
@@ -134,6 +134,8 @@ def testbed():
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
+    outcome = yield
+    outcome.get_result()
     test_fn = item.obj
     docstring = getattr(test_fn, '__doc__')
     if docstring:


### PR DESCRIPTION
Pytest fails with an error:
```
E   pluggy._manager.PluginValidationError: Plugin '/usr/local/lib/python3.10/dist-packages/dent_os_testbed/test/conftest.py' for hook 'pytest_runtest_makereport'
E   hookimpl definition: pytest_runtest_makereport(item, call)
E   Declared as hookwrapper=True but function is not a generator function
```
`@pytest.hookimpl` expects `pytest_runtest_makereport` to be a generator, so restore the previous behavior by adding yield to the function.

Fixes: https://github.com/dentproject/testing/pull/294

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>