### PR TITLE
Add parameters to IpLink and IpRoute APIs

### DIFF
--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_link_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_link_impl.py
@@ -140,6 +140,8 @@ class LinuxIpLinkImpl(LinuxIpLink):
             cmd += 'mcast_querier {} '.format((params['mcast_querier']))
         if 'mcast_querier_interval' in params:
             cmd += 'mcast_querier_interval {} '.format((params['mcast_querier_interval']))
+        if 'vlan_default_pvid' in params:
+            cmd += 'vlan_default_pvid {} '.format((params['vlan_default_pvid']))
         return cmd
 
     def format_show(self, command, *argv, **kwarg):

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_route_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_route_impl.py
@@ -148,6 +148,8 @@ class LinuxIpRouteImpl(LinuxIpRoute):
             params['cmd_options'] = '-j -d'
         cmd = 'ip {} route {} '.format(params.get('cmd_options', ''), command)
         cmd += params.get('dst', '') + ' '
+        if 'dev' in params:
+            cmd += 'dev {} '.format(params['dev'])
         if 'root' in params:
             cmd += 'root {} '.format(params.get('root'))
         if 'match' in params:


### PR DESCRIPTION
**Update linux_ip_route_impl.py**
✓ Add parameter `dev` to `format_show` function

**Update linux_ip_link_impl.py**
✓ Add parameter `vlan_default_pvid` to `format_set` function