### PR TITLE
Add cleanup_bonds function

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/conftest.py
@@ -17,6 +17,7 @@ from dent_os_testbed.utils.test_utils.cleanup_utils import (
     cleanup_bridges as _cleanup_bridges,
     cleanup_qdiscs as _cleanup_qdiscs,
     cleanup_routes as _cleanup_routes,
+    cleanup_bonds as _cleanup_bonds,
     cleanup_vrfs as _cleanup_vrfs,
     cleanup_sysctl as _cleanup_sysctl,
     get_initial_routes,
@@ -201,3 +202,11 @@ async def cleanup_routes(testbed):
 async def cleanup_sysctl():
     yield
     await _cleanup_sysctl()
+
+
+@pytest_asyncio.fixture
+async def cleanup_bonds(testbed):
+    yield
+    _, devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    bonds_cleanup = [_cleanup_bonds(dev) for dev in devices]
+    await asyncio.gather(*bonds_cleanup)


### PR DESCRIPTION
Add `cleanup_bonds(dev)` function for remove all bonds created during test.

**For example:**
` await cleanup_bonds(dent_dev)`