### PR TITLE
Add IPv6/IPv4 and IPv6 route tests

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/conftest.py
@@ -48,26 +48,36 @@ async def remove_default_gateway(testbed):
     dent = dent_devices[0].host_name
 
     out = await IpRoute.show(input_data=[{dent: [
-        {'cmd_options': '-j'}
+        {'cmd_options': '-j -4'}
     ]}], parse_output=True)
-    assert out[0][dent]['rc'] == 0, 'Failed to get list of route entries'
-
+    assert out[0][dent]['rc'] == 0, 'Failed to get list of IPv4 route entries'
     # save default route to restore it later
-    def_route = [route for route in out[0][dent]['parsed_output'] if route['dst'] == 'default']
+    def_routes = [route for route in out[0][dent]['parsed_output'] if route['dst'] == 'default']
+
+    out = await IpRoute.show(input_data=[{dent: [
+        {'cmd_options': '-j -6'}
+    ]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0, 'Failed to get list of IPv6 route entries'
+    # save default route to restore it later
+    def_routes += [route for route in out[0][dent]['parsed_output'] if route['dst'] == 'default']
 
     out = await IpRoute.delete(input_data=[{dent: [
         {'dev': route['dev'], 'type': 'default', 'via': route['gateway']}
-        for route in def_route
+        for route in def_routes
     ]}])
     assert out[0][dent]['rc'] == 0, 'Failed to remove default route'
 
     yield  # Run the test
 
     out = await IpRoute.show(input_data=[{dent: [
-        {'cmd_options': '-j'}
+        {'cmd_options': '-j -4'}
     ]}], parse_output=True)
-
     default_routes = [route for route in out[0][dent]['parsed_output'] if route['dst'] == 'default']
+
+    out = await IpRoute.show(input_data=[{dent: [
+        {'cmd_options': '-j -6'}
+    ]}], parse_output=True)
+    default_routes += [route for route in out[0][dent]['parsed_output'] if route['dst'] == 'default']
 
     if default_routes:
         # Remove non-default gateways
@@ -79,7 +89,7 @@ async def remove_default_gateway(testbed):
     # Restore default gateway
     out = await IpRoute.replace(input_data=[{dent: [
         {'dev': route['dev'], 'type': 'default', 'via': route['gateway']}
-        for route in def_route
+        for route in def_routes
     ]}])
 
 

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/ipv6_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/ipv6_utils.py
@@ -5,59 +5,97 @@ from dent_os_testbed.lib.ip.ip_neighbor import IpNeighbor
 
 async def verify_dut_routes(dent, expected_routes):
     out = await IpRoute.show(input_data=[{dent: [
+        {'cmd_options': '-j -4'},
+    ]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0, 'Failed to get IPv4 routes'
+    routes = out[0][dent]['parsed_output']
+
+    out = await IpRoute.show(input_data=[{dent: [
         {'cmd_options': '-j -6'},
     ]}], parse_output=True)
     assert out[0][dent]['rc'] == 0, 'Failed to get IPv6 routes'
+    routes += out[0][dent]['parsed_output']
 
-    for route in out[0][dent]['parsed_output']:
-        dev = route['dev']
-        if dev not in expected_routes:
-            continue
-        if route['dst'].startswith('f'):  # broadcast
-            continue
-        assert 'rt_trap' in route['flags'], 'Route should be offloaded'
-        assert route['dst'] in expected_routes[dev], \
-            f"Expected route to be one of {expected_routes[dev]}, not {route['dst']}"
+    for expected_route in expected_routes:
+        for route in routes:
+            for key in expected_route:  # find matching route
+                if key == 'flags':
+                    continue
+                if expected_route[key] != route[key]:
+                    break
+            else:  # route found
+                assert all(flag in route['flags'] for flag in expected_route['flags']), \
+                    f'Route {route} should have {expected_route["flags"]} flags'
+                break
+        else:  # route not found
+            raise LookupError(f'Route {expected_route} expected, but not found')
 
 
 async def verify_dut_neighbors(dent, expected_neis):
     out = await IpNeighbor.show(input_data=[{dent: [
+        {'cmd_options': '-j -4'},
+    ]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0, 'Failed to get IPv4 neighbors'
+    neighbors = out[0][dent]['parsed_output']
+
+    out = await IpNeighbor.show(input_data=[{dent: [
         {'cmd_options': '-j -6'},
     ]}], parse_output=True)
     assert out[0][dent]['rc'] == 0, 'Failed to get IPv6 neighbors'
+    neighbors += out[0][dent]['parsed_output']
+
+    for expected_nei in expected_neis:
+        for nei in neighbors:
+            for key in expected_nei:  # find matching neighbor
+                if key == 'states':
+                    continue
+                if expected_nei[key] != nei[key]:
+                    break
+            else:  # neighbor found
+                assert 'offload' in nei, f'Neighbor {nei} should be offloaded'
+                assert nei['state'][0] in expected_nei['states'], \
+                    f'Neighbor {nei} should have one of {expected_nei["states"]} states'
+                break
+        else:  # neighbor not found
+            raise LookupError(f'Neighbor {expected_nei} expected, but not found')
 
     learned_macs = {}
-    for nei in out[0][dent]['parsed_output']:
-        dev = nei['dev']
-        if dev not in expected_neis:
-            continue
-        if nei['dst'].startswith('f'):  # broadcast
-            continue
-        assert nei['dst'] in expected_neis[dev], \
-            f"Expected neighbor to be one of {expected_neis[dev]}, not {nei['dst']}"
-        assert 'offload' in nei, 'Neighbor should be offloaded'
-        assert nei['state'] != 'FAILED', 'Unexpected neighbor state'
-        if dev not in learned_macs:
-            learned_macs[dev] = []
-        learned_macs[dev].append(nei['lladdr'])
+    for nei in neighbors:
+        if nei['dev'] not in learned_macs:
+            learned_macs[nei['dev']] = []
+        learned_macs[nei['dev']].append(nei['lladdr'])
     return learned_macs
 
 
-async def verify_dut_addrs(dent, expected_addrs, plen=64):
+async def verify_dut_addrs(dent, expected_addrs, expect_family=('inet', 'inet6')):
     out = await IpAddress.show(input_data=[{dent: [
-        {'cmd_options': '-j'}
+        {'cmd_options': '-j -4'}
     ]}], parse_output=True)
-    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+    assert out[0][dent]['rc'] == 0, 'Failed to get IPv4 addr'
+    links = out[0][dent]['parsed_output']
 
-    for link in out[0][dent]['parsed_output']:
-        dev = link['ifname']
-        if dev not in expected_addrs:
-            continue
-        for addr in link['addr_info']:
-            ip = addr['local']
-            assert addr['family'] == 'inet6', 'Expected only IPv6 addresses'
-            if ip.startswith('f'):  # broadcast
+    out = await IpAddress.show(input_data=[{dent: [
+        {'cmd_options': '-j -6'}
+    ]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0, 'Failed to get IPv6 addr'
+    links += out[0][dent]['parsed_output']
+
+    for swp, ip, plen in expected_addrs:
+        for link in links:
+            if swp != link['ifname']:
                 continue
-            assert int(addr['prefixlen']) == plen, f'Expected prefix to be {plen}'
-            assert ip in expected_addrs[dev], \
-                f'Expected IP addr to be one of {expected_addrs[dev]}, not {ip}'
+            # link found
+            for addr in link['addr_info']:
+                if ip != addr['local']:
+                    continue
+                # IP addr found
+                assert addr['family'] in expect_family, f'Expected {addr} to be {expect_family}'
+                assert addr['prefixlen'] == plen, f'Expected {addr} prefix length to be {plen}'
+                break
+            else:  # IP addr not found
+                # `links` list might have duplicate entries (for ipv4 and ipv6),
+                # thus we need to look through all of the entries.
+                continue
+            break
+        else:  # `swp` with `ip` addr not found
+            raise LookupError(f'IP addr {swp, addr} expected, but not found')

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6.py
@@ -5,10 +5,6 @@ import pytest
 from dent_os_testbed.lib.ip.ip_link import IpLink
 from dent_os_testbed.lib.ip.ip_address import IpAddress
 
-from dent_os_testbed.utils.test_utils.tb_utils import (
-    tb_ping_device,
-)
-
 from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_dent_devices_with_tgen,
     tgen_utils_traffic_generator_connect,
@@ -18,7 +14,6 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_start_traffic,
     tgen_utils_stop_traffic,
     tgen_utils_get_loss,
-    tgen_utils_send_ns,
 )
 
 from dent_os_testbed.test.test_suite.functional.ipv6.ipv6_utils import (
@@ -113,14 +108,6 @@ async def test_ipv6_basic_config(testbed):
         },
     }
     await tgen_utils_setup_streams(tgen_dev, None, streams)
-
-    out = await tgen_utils_send_ns(tgen_dev, [{'ixp': tg}
-                                              for tg in tg_ports])
-    assert all(status['success'] for status in out), 'Failed to send IPv6 NS'
-
-    out = await asyncio.gather(*[tb_ping_device(dent_dev, info.tg_ip, pkt_loss_treshold=0, dump=True)
-                                 for info in address_map])
-    assert all(rc == 0 for rc in out), 'Some pings from DUT did not have a reply'
 
     await tgen_utils_start_traffic(tgen_dev)
     await asyncio.sleep(traffic_duration)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_bridge.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_bridge.py
@@ -7,10 +7,6 @@ from dent_os_testbed.lib.ip.ip_link import IpLink
 from dent_os_testbed.lib.ip.ip_address import IpAddress
 from dent_os_testbed.lib.bridge.bridge_vlan import BridgeVlan
 
-from dent_os_testbed.utils.test_utils.tb_utils import (
-    tb_ping_device,
-)
-
 from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_dent_devices_with_tgen,
     tgen_utils_traffic_generator_connect,
@@ -126,10 +122,6 @@ async def test_ipv6_on_bridge(testbed):
     await verify_dut_routes(dent, expected_routes)
 
     # 3. Send bidirectional traffic between TG ports for primary IP addresses
-    out = await asyncio.gather(*[tb_ping_device(dent_dev, info.tg_ip, pkt_loss_treshold=0, dump=True)
-                                 for info in address_map])
-    assert all(rc == 0 for rc in out), 'Some pings from DUT did not have a reply'
-
     await tgen_utils_start_traffic(tgen_dev)
     await asyncio.sleep(traffic_duration)
     await tgen_utils_stop_traffic(tgen_dev)
@@ -254,10 +246,6 @@ async def test_ipv6_on_bridge_vlan(testbed):
     await tgen_utils_setup_streams(tgen_dev, None, streams)
 
     # Send traffic
-    out = await asyncio.gather(*[tb_ping_device(dent_dev, info.tg_ip, pkt_loss_treshold=0, dump=True)
-                                 for info in address_map])
-    assert all(rc == 0 for rc in out), 'Some pings from DUT did not have a reply'
-
     await tgen_utils_start_traffic(tgen_dev)
     await asyncio.sleep(traffic_duration)
     await tgen_utils_stop_traffic(tgen_dev)
@@ -348,17 +336,13 @@ async def test_ipv6_move_host_on_bridge(testbed):
     await tgen_utils_setup_streams(tgen_dev, None, streams)
 
     # 2. Verify IP configuration: no errors on IP address adding, connected routes added and offloaded
-    expected_routes = {
-        info.swp: [info.swp_ip[:-1] + f'/{info.plen}']
-        for info in address_map
-    }
+    expected_routes = [{'dev': info.swp,
+                        'dst': info.swp_ip[:-1] + f'/{info.plen}',
+                        'flags': ['rt_trap']}
+                       for info in address_map]
     await verify_dut_routes(dent, expected_routes)
 
     # 3. Send bidirectional traffic between TG ports for primary IP addresses
-    out = await asyncio.gather(*[tb_ping_device(dent_dev, info.tg_ip, pkt_loss_treshold=0, dump=True)
-                                 for info in address_map[:2]])
-    assert all(rc == 0 for rc in out), 'Some pings from DUT did not have a reply'
-
     await tgen_utils_start_traffic(tgen_dev)
     await asyncio.sleep(traffic_duration)
     await tgen_utils_stop_traffic(tgen_dev)
@@ -406,10 +390,6 @@ async def test_ipv6_move_host_on_bridge(testbed):
     await tgen_utils_setup_streams(tgen_dev, None, streams)
 
     # 6. Send bidirectional traffic between TG ports for primary IP addresses
-    out = await asyncio.gather(*[tb_ping_device(dent_dev, info.tg_ip, pkt_loss_treshold=0, dump=True)
-                                 for info in address_map[::2]])
-    assert all(rc == 0 for rc in out), 'Some pings from DUT did not have a reply'
-
     await tgen_utils_start_traffic(tgen_dev)
     await asyncio.sleep(traffic_duration)
     await tgen_utils_stop_traffic(tgen_dev)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_ipv4.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_ipv4.py
@@ -1,0 +1,386 @@
+from collections import namedtuple
+import asyncio
+import pytest
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_route import IpRoute
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+from dent_os_testbed.lib.ip.ip_neighbor import IpNeighbor
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_clear_traffic_items,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
+    tgen_utils_get_loss,
+)
+
+from dent_os_testbed.test.test_suite.functional.ipv6.ipv6_utils import (
+    verify_dut_neighbors,
+    verify_dut_routes,
+)
+
+pytestmark = [
+    pytest.mark.suite_functional_ipv6,
+    pytest.mark.usefixtures('cleanup_ip_addrs', 'enable_ipv6_forwarding', 'enable_ipv4_forwarding'),
+    pytest.mark.asyncio,
+]
+
+
+async def test_ipv64_nh_reconfig(testbed):
+    """
+    Test Name: test_ipv64_nh_reconfig
+    Test Suite: suite_functional_ipv6
+    Test Overview:
+        Verify IPv4/IPv6/IPv4 configuration on the port applied
+        Verify clear traffic for IPv4 and IPv6
+        Verify IPv4 and IPv6 routes are offloaded
+    Test Procedure:
+    1. Add IP interfaces for TG
+    2. Set ports up
+    3. Add IPv4 address for DUT
+    4. Add static neighbors and nexthop routes
+    5. Configure IPv4 bidirectional host to host streams
+       Configure IPv4 unidirectional stream for nexthop
+    6. Send traffic. Verify no losses
+    7. Verify connected IPv4 routes added and offloaded, neighbors resolved
+    8. Repeat steps 3-7 for IPv6
+    9. Repeat steps 3-7 for IPv4 again
+    """
+    num_of_ports = 4
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], num_of_ports)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dent_dev = dent_devices[0]
+    dent = dent_dev.host_name
+    tg_ports = tgen_dev.links_dict[dent][0][:num_of_ports]
+    ports = tgen_dev.links_dict[dent][1][:num_of_ports]
+    addr_info = namedtuple('addr_info', ['swp', 'tg', 'swp_ip', 'tg_ip', 'plen'])
+    nh_info = namedtuple('nh_info', ['swp', 'tg', 'dst', 'via', 'plen', 'mac'])
+    traffic_duration = 10
+    wait_for_stats = 5
+    nh_src_idx = 3
+    nh_dst_idx = 0
+    IPV4 = 0
+    IPV6 = 1
+
+    address_map = {
+        IPV4: [
+            addr_info(port, tg, f'1.{idx}.1.1', f'1.{idx}.1.2', 24)
+            for idx, (port, tg) in enumerate(zip(ports, tg_ports), start=1)
+        ],
+        IPV6: [
+            addr_info(port, tg, f'2001:{idx}::1', f'2001:{idx}::2', 64)
+            for idx, (port, tg) in enumerate(zip(ports, tg_ports), start=1)
+        ],
+    }
+    nh_route = {
+        IPV4: nh_info(
+            address_map[IPV4][nh_dst_idx].swp,
+            address_map[IPV4][nh_dst_idx].tg,
+            '48.0.0.0',
+            address_map[IPV4][nh_dst_idx].swp_ip[:-1] + '5',  # 1.1.1.5
+            address_map[IPV4][nh_dst_idx].plen,
+            '02:00:00:00:00:01',
+        ),
+        IPV6: nh_info(
+            address_map[IPV6][nh_dst_idx].swp,
+            address_map[IPV6][nh_dst_idx].tg,
+            '2001:1234::',
+            address_map[IPV6][nh_dst_idx].swp_ip[:-1] + '5',  # 2001:1::5
+            address_map[IPV6][nh_dst_idx].plen,
+            '02:00:00:00:00:02',
+        ),
+    }
+
+    out = await IpLink.show(input_data=[{dent: [
+        {'cmd_options': '-j'}
+    ]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0, 'Failed to get port info'
+
+    dut_mac = {link['ifname']: link['address']
+               for link in out[0][dent]['parsed_output']
+               if link['ifname'] in ports}
+
+    # 1. Add IP interfaces for TG
+    dev_groups = tgen_utils_dev_groups_from_config([
+        {'ixp': info.tg, 'ip': info.tg_ip, 'gw': info.swp_ip,
+         'plen': info.plen}
+        for info in address_map[IPV4]
+    ] + [
+        {'ixp': info.tg, 'ip': info.tg_ip, 'gw': info.swp_ip,
+         'plen': info.plen, 'version': 'ipv6'}
+        for info in address_map[IPV6]
+    ])
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    # 2. Set ports up
+    out = await IpLink.set(input_data=[{dent: [
+        {'device': port, 'operstate': 'up'} for port in ports
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to set port state UP'
+
+    for version in (IPV4, IPV6, IPV4):
+        # 3. Add IPv4 address for DUT
+        out = await IpAddress.add(input_data=[{dent: [
+            {'dev': info.swp, 'prefix': f'{info.swp_ip}/{info.plen}'}
+            for info in address_map[version]
+        ]}])
+        assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+        # 4. Add static neighbors and nexthop routes
+        out = await IpNeighbor.add(input_data=[{dent: [
+            {'dev': nh_route[version].swp,
+             'address': nh_route[version].via,
+             'lladdr': nh_route[version].mac},
+        ]}])
+        assert out[0][dent]['rc'] == 0, 'Failed to add static arp entries'
+
+        out = await IpRoute.add(input_data=[{dent: [
+            {'dst': f'{nh_route[version].dst}/{nh_route[version].plen}',
+             'nexthop': [{'via': nh_route[version].via}]},
+        ]}])
+        assert out[0][dent]['rc'] == 0, 'Failed to add nexthop'
+
+        # 5. Configure IPv4 bidirectional host to host streams
+        proto = 'ipv4' if version == IPV4 else 'ipv6'
+        streams = {f'{src} <-> {[dst for dst in tg_ports if src < dst]}': {
+            'type': proto,
+            'rate': 10000,  # pps
+            'ip_source': dev_groups[src][version]['name'],
+            'ip_destination': [dev_groups[dst][version]['name'] for dst in tg_ports if src < dst],
+            'bi_directional': True}
+            for src in tg_ports[:-1]
+        }
+        # Configure IPv4 unidirectional stream for nexthop
+        streams.update({f'{tg_ports[nh_src_idx]} -> nexthop': {
+            'type': 'raw',
+            'protocol': proto,
+            'ip_source': dev_groups[tg_ports[nh_src_idx]][version]['name'],
+            'ip_destination': dev_groups[nh_route[version].tg][version]['name'],
+            'rate': 10000,  # pps
+            'srcMac': '02:00:00:00:00:05',
+            'dstMac': dut_mac[ports[nh_src_idx]],
+            'srcIp': '5.0.0.5' if version == IPV4 else '2001:5::5',
+            'dstIp': nh_route[version].dst,
+        }})
+        await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+        # 6. Send traffic
+        await tgen_utils_start_traffic(tgen_dev)
+        await asyncio.sleep(traffic_duration)
+        await tgen_utils_stop_traffic(tgen_dev)
+
+        # Verify no losses
+        await asyncio.sleep(wait_for_stats)
+        stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+        for row in stats.Rows:
+            loss = tgen_utils_get_loss(row)
+            assert loss == 0, f'Expected loss: 0%, actual: {loss}%'
+
+        # 7. Verify neighbors resolved
+        out = await IpNeighbor.show(input_data=[{dent: [
+            {'cmd_options': '-j -' + proto[-1]},  # -4/-6
+        ]}], parse_output=True)
+        assert out[0][dent]['rc'] == 0, 'Failed to get neighbors'
+
+        expected_neis = [{'dev': info.swp,
+                          'dst': info.tg_ip,
+                          'states': ['REACHABLE', 'PROBE', 'STALE', 'DELAY']}
+                         for info in address_map[version]]
+        expected_neis += [{'dev': nh_route[version].swp,
+                           'dst': nh_route[version].via,
+                           'states': ['PERMANENT']}]
+        await verify_dut_neighbors(dent, expected_neis)
+
+        # Verify connected IPv4 routes added and offloaded
+        out = await IpRoute.show(input_data=[{dent: [
+            {'cmd_options': '-j -' + proto[-1]},  # -4/-6
+        ]}], parse_output=True)
+        assert out[0][dent]['rc'] == 0, 'Failed to get routes'
+
+        expected_routes = [{'dev': info.swp,
+                            'dst': info.swp_ip[:-1] + ('0/' if version == IPV4 else '/') + str(info.plen),
+                            'flags': ['rt_trap']}
+                           for info in address_map[version]]
+        expected_routes += [{'dev': nh_route[version].swp,
+                             'dst': f'{nh_route[version].dst}/{nh_route[version].plen}',
+                             'flags': ['offload', 'rt_offload']}]
+        await verify_dut_routes(dent, expected_routes)
+
+        # clear traffic items and ip addrs to prepare for the next iteration
+        await tgen_utils_clear_traffic_items(tgen_dev)
+        out = await IpAddress.delete(input_data=[{dent: [
+            {'dev': info.swp, 'prefix': f'{info.swp_ip}/{info.plen}'}
+            for info in address_map[version]
+        ]}])
+        assert out[0][dent]['rc'] == 0, 'Failed to remove IP addr from port'
+
+
+async def test_ipv64_nh_routes(testbed):
+    """
+    Test Name: test_ipv64_nh_routes
+    Test Suite: suite_functional_ipv6
+    Test Overview:
+        Verify IPv4 and IPv6 configuration on the port applied
+        Verify clear traffic for IPv4 and IPv6
+        Verify IPv4 and IPv6 routes are offloaded
+    Test Procedure:
+    1. Set ports up. Add IPv4 and IPv6 address for interfaces
+    2. Add static neighbors. Add nexthop routes
+    3. Configure IPv4 and IPv6 bidirectional streams
+    4. Configure IPv4 and IPv6 unidirectional stream for nexthop
+    5. Send traffic. Verify no losses
+    6. Verify connected routes added and offloaded, neighbors resolved
+    """
+    num_of_ports = 4
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], num_of_ports)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dent_dev = dent_devices[0]
+    dent = dent_dev.host_name
+    tg_ports = tgen_dev.links_dict[dent][0][:num_of_ports]
+    ports = tgen_dev.links_dict[dent][1][:num_of_ports]
+    addr_info = namedtuple('addr_info', ['swp', 'tg', 'swp_ip', 'tg_ip', 'plen'])
+    nh_info = namedtuple('nh_info', ['swp', 'tg', 'dst', 'via', 'plen', 'mac'])
+    traffic_duration = 10
+    wait_for_stats = 5
+
+    address_map = (
+        addr_info(ports[0], tg_ports[0], '1.1.1.1', '1.1.1.2', 24),
+        addr_info(ports[1], tg_ports[1], '2001:2::1', '2001:2::2', 64),
+        addr_info(ports[2], tg_ports[2], '1.3.1.1', '1.3.1.2', 24),
+        addr_info(ports[3], tg_ports[3], '2001:4::1', '2001:4::2', 64),
+    )
+    nh_route = (
+        nh_info(
+            address_map[0].swp,
+            address_map[0].tg,
+            '48.0.0.0',
+            address_map[0].swp_ip[:-1] + '5',  # 1.1.1.5
+            address_map[0].plen,
+            '02:00:00:00:00:01',
+        ),
+        nh_info(
+            address_map[1].swp,
+            address_map[1].tg,
+            '2001:1234::',
+            address_map[1].swp_ip[:-1] + '5',  # 2001:2::5
+            address_map[1].plen,
+            '02:00:00:00:00:02',
+        ),
+    )
+
+    out = await IpLink.show(input_data=[{dent: [
+        {'cmd_options': '-j'}
+    ]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0, 'Failed to get port info'
+
+    dut_mac = {link['ifname']: link['address']
+               for link in out[0][dent]['parsed_output']
+               if link['ifname'] in ports}
+
+    # 1. Set ports up
+    out = await IpLink.set(input_data=[{dent: [
+        {'device': port, 'operstate': 'up'} for port in ports
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to set port state UP'
+
+    # Add IPv4 and IPv6 address for interfaces
+    dev_groups = tgen_utils_dev_groups_from_config([
+        {'ixp': info.tg, 'ip': info.tg_ip, 'gw': info.swp_ip,
+         'plen': info.plen, 'version': 'ipv6' if ':' in info.tg_ip else 'ipv4'}
+        for info in address_map
+    ])
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    out = await IpAddress.add(input_data=[{dent: [
+        {'dev': info.swp, 'prefix': f'{info.swp_ip}/{info.plen}'}
+        for info in address_map
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    # 2. Add static neighbors
+    out = await IpNeighbor.add(input_data=[{dent: [
+        {'dev': route.swp,
+         'address': route.via,
+         'lladdr': route.mac}
+        for route in nh_route
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add static arp entries'
+
+    # Add nexthop routes
+    out = await IpRoute.add(input_data=[{dent: [
+        {'dst': f'{route.dst}/{route.plen}',
+         'nexthop': [{'via': route.via}]}
+        for route in nh_route
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add nexthop'
+
+    # 3. Configure IPv4 and IPv6 bidirectional streams
+    streams = {
+        f'{proto}: {src} <-> {dst}': {
+            'type': proto,
+            'rate': 10000,  # pps
+            'ip_source': dev_groups[src][0]['name'],
+            'ip_destination': dev_groups[dst][0]['name'],
+            'bi_directional': True,
+        }
+        for src, dst, proto in ((tg_ports[0], tg_ports[2], 'ipv4'),
+                                (tg_ports[1], tg_ports[3], 'ipv6'))
+    }
+    # 4. Configure IPv4 and IPv6 unidirectional stream for nexthop
+    streams.update({
+        f'{proto}: {src} -> nexthop': {
+            'type': 'raw',
+            'protocol': proto,
+            'ip_source': dev_groups[src.tg][0]['name'],
+            'ip_destination': dev_groups[dst.tg][0]['name'],
+            'rate': 10000,  # pps
+            'srcMac': '02:00:00:00:00:05',
+            'dstMac': dut_mac[src.swp],
+            'srcIp': '5.0.0.5' if proto == 'ipv4' else '2001:5::5',
+            'dstIp': dst.dst,
+        }
+        for src, dst, proto in ((address_map[2], nh_route[0], 'ipv4'),
+                                (address_map[3], nh_route[1], 'ipv6'))
+    })
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    # 5. Send traffic
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # Verify no losses
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    for row in stats.Rows:
+        loss = tgen_utils_get_loss(row)
+        assert loss == 0, f'Expected loss: 0%, actual: {loss}%'
+
+    # 6. Verify neighbors resolved
+    expected_neis = [{'dev': info.swp,
+                      'dst': info.tg_ip,
+                      'states': ['REACHABLE', 'PROBE', 'STALE', 'DELAY']}
+                     for info in address_map]
+    expected_neis += [{'dev': route.swp,
+                       'dst': route.via,
+                       'states': ['PERMANENT']}
+                      for route in nh_route]
+    await verify_dut_neighbors(dent, expected_neis)
+
+    # Verify connected routes added and offloaded
+    expected_routes = [{'dev': info.swp,
+                        'dst': info.swp_ip[:-1] + ('/' if ':' in info.swp_ip else '0/') + str(info.plen),
+                        'flags': ['rt_trap']}
+                       for info in address_map]
+    expected_routes += [{'dev': route.swp,
+                         'dst': f'{route.dst}/{route.plen}',
+                         'flags': ['offload', 'rt_offload']}
+                        for route in nh_route]
+    await verify_dut_routes(dent, expected_routes)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_route.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_route.py
@@ -1,0 +1,341 @@
+from collections import namedtuple
+import asyncio
+import pytest
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_route import IpRoute
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
+    tgen_utils_get_loss,
+)
+
+from dent_os_testbed.test.test_suite.functional.ipv6.ipv6_utils import (
+    verify_dut_routes,
+)
+
+pytestmark = [
+    pytest.mark.suite_functional_ipv6,
+    pytest.mark.usefixtures('cleanup_ip_addrs', 'enable_ipv6_forwarding'),
+    pytest.mark.asyncio,
+]
+
+
+@pytest.mark.usefixtures('remove_default_gateway')
+async def test_ipv6_route_default_offload(testbed):
+    """
+    Test Name: test_ipv6_route_default_offload
+    Test Suite: suite_functional_ipv6
+    Test Overview:
+        Verify default GW offloading
+    Test Procedure:
+    1. Add IP address
+    2. Add default routes via 2nd and 3rd interfaces
+    3. Verify the route to the network with best metric is the only offloaded route
+    4. Send traffic and verify it's passed through the route with best metric
+    5. Add default route with best metrics via 3rd interface
+    6. Verify the route to the network with best metric is the only offloaded route
+    7. Send traffic and verify it's passed through the route with best metric
+    """
+    num_of_ports = 3
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], num_of_ports)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dent_dev = dent_devices[0]
+    dent = dent_dev.host_name
+    tg_ports = tgen_dev.links_dict[dent][0][:num_of_ports]
+    ports = tgen_dev.links_dict[dent][1][:num_of_ports]
+    addr_info = namedtuple('addr_info', ['swp', 'tg', 'swp_ip', 'tg_ip', 'plen'])
+    traffic_duration = 10
+    wait_for_stats = 5
+    dip = '2001:5555::5'
+
+    address_map = (
+        addr_info(ports[0], tg_ports[0], '2001:1111::1', '2001:1111::2', 64),
+        addr_info(ports[1], tg_ports[1], '2001:2222::1', '2001:2222::2', 64),
+        addr_info(ports[2], tg_ports[2], '2001:3333::1', '2001:3333::2', 64),
+    )
+
+    route_map = [
+        {'port': port, 'gw': def_gw, 'metric': metric, 'should_offload': metric == 200}
+        for (port, _, _, def_gw, _), metric in zip(address_map[1:], (200, 300))
+    ]
+
+    out = await IpLink.show(input_data=[{dent: [
+        {'cmd_options': '-j'}
+    ]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0, 'Failed to get port info'
+
+    dut_mac = {link['ifname']: link['address']
+               for link in out[0][dent]['parsed_output']
+               if link['ifname'] in ports}
+    tg_to_swp = {tg: swp for tg, swp in zip(tg_ports, ports)}
+
+    # Configure ports up
+    out = await IpLink.set(input_data=[{dent: [
+        {'device': port, 'operstate': 'up'} for port in ports
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to set port state UP'
+
+    # 1. Add IP address
+    out = await IpAddress.add(input_data=[{dent: [
+        {'dev': info.swp, 'prefix': f'{info.swp_ip}/{info.plen}'}
+        for info in address_map
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        {'ixp': info.tg, 'ip': info.tg_ip, 'gw': info.swp_ip,
+         'plen': info.plen, 'version': 'ipv6'}
+        for info in address_map
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    streams = {
+        f'{src} -> {dip}': {
+            'type': 'raw',
+            'protocol': 'ipv6',
+            'ip_source': dev_groups[src][0]['name'],
+            'ip_destination': [dev_groups[tg][0]['name'] for tg in dst],
+            'rate': 10000,  # pps
+            'srcMac': '02:00:00:00:00:01',
+            'dstMac': dut_mac[tg_to_swp[src]],
+            'srcIp': dev_groups[src][0]['ip'],
+            'dstIp': dip,
+        } for src, *dst in (tg_ports,)
+    }
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    # 2. Add default routes via 2nd and 3rd interfaces
+    out = await IpRoute.add(input_data=[{dent: [
+        {'dev': route['port'], 'type': 'default', 'via': route['gw'], 'metric': route['metric']}
+        for route in route_map
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add default routes'
+
+    # 3. Verify the route to the network with best metric is the only offloaded route
+    expected_routes = [{'dev': route['port'],
+                        'dst': 'default',
+                        'gateway': route['gw'],
+                        'metric': route['metric'],
+                        'flags': ['rt_offload'] if route['should_offload'] else []}
+                       for route in route_map]
+    await verify_dut_routes(dent, expected_routes)
+
+    # 4. Send traffic and verify it's passed through the route with best metric
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    for row in stats.Rows:
+        loss = tgen_utils_get_loss(row)
+        expected = 0 if tg_ports[1] == row['Rx Port'] else 100
+        assert loss == expected, f'Expected loss: {expected}%, actual: {loss}%'
+
+    # 5. Add default route with best metrics via 3rd interface
+    route_map[0]['should_offload'] = False
+    route_map[1]['should_offload'] = True
+    route_map[1]['metric'] = 100
+    out = await IpRoute.add(input_data=[{dent: [
+        {'dev': route['port'], 'type': 'default', 'via': route['gw'], 'metric': route['metric']}
+        for route in (route_map[1],)
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add default routes'
+
+    # 6. Verify the route to the network with best metric is the only offloaded route
+    expected_routes = [{'dev': route['port'],
+                        'dst': 'default',
+                        'gateway': route['gw'],
+                        'metric': route['metric'],
+                        'flags': ['rt_offload'] if route['should_offload'] else []}
+                       for route in route_map]
+    await verify_dut_routes(dent, expected_routes)
+
+    # 7. Send traffic and verify it's passed through the route with best metric
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    for row in stats.Rows:
+        loss = tgen_utils_get_loss(row)
+        expected = 0 if tg_ports[2] == row['Rx Port'] else 100
+        assert loss == expected, f'Expected loss: {expected}%, actual: {loss}%'
+
+
+async def test_ipv6_route_hosts_offload(testbed):
+    """
+    Test Name: test_ipv6_route_hosts_offload
+    Test Suite: suite_functional_ipv6
+    Test Overview:
+        Verify LPM proper processing
+    Test Procedure:
+    1. Add IP address
+    2. Add next hop routes. Send one way traffic. Verify packets received on port#2
+    3. Verify routes offloaded
+    4. Remove next hop route. Send one way traffic. Verify packets received on port#1
+    5. Verify routes offloaded
+    6. Add next hop routes. Send one way traffic. Verify packets received on port#3
+    7. Verify routes offloaded
+    """
+    num_of_ports = 4
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], num_of_ports)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dent_dev = dent_devices[0]
+    dent = dent_dev.host_name
+    tg_ports = tgen_dev.links_dict[dent][0][:num_of_ports]
+    ports = tgen_dev.links_dict[dent][1][:num_of_ports]
+    addr_info = namedtuple('addr_info', ['swp', 'tg', 'swp_ip', 'tg_ip', 'plen'])
+    traffic_duration = 10
+    wait_for_stats = 5
+
+    address_map = (
+        addr_info(ports[0], tg_ports[0], '2001:1111::1', '2001:1111::2', 64),
+        addr_info(ports[1], tg_ports[1], '2001:2222::1', '2001:2222::2', 64),
+        addr_info(ports[2], tg_ports[2], '2001:3333::1', '2001:3333::2', 64),
+        addr_info(ports[3], tg_ports[3], '2001:4444::1', '2001:4444::2', 64),
+    )
+
+    out = await IpLink.show(input_data=[{dent: [
+        {'cmd_options': '-j'}
+    ]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0, 'Failed to get port info'
+
+    dut_mac = {link['ifname']: link['address']
+               for link in out[0][dent]['parsed_output']
+               if link['ifname'] in ports}
+    tg_to_swp = {tg: swp for tg, swp in zip(tg_ports, ports)}
+
+    # Configure ports up
+    out = await IpLink.set(input_data=[{dent: [
+        {'device': port, 'operstate': 'up'} for port in ports
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to set port state UP'
+
+    # 1. Add IP address
+    out = await IpAddress.add(input_data=[{dent: [
+        {'dev': info.swp, 'prefix': f'{info.swp_ip}/{info.plen}'}
+        for info in address_map
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        {'ixp': info.tg, 'ip': info.tg_ip, 'gw': info.swp_ip,
+         'plen': info.plen, 'version': 'ipv6'}
+        for info in address_map
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    routes = [('2002:1::', 64, address_map[1]), ('2002:1::2', 128, address_map[2])]
+    streams = {
+        'traffic': {
+            'type': 'raw',
+            'protocol': 'ipv6',
+            'ip_source': dev_groups[tg_ports[0]][0]['name'],
+            'rate': 10000,  # pps
+            'srcMac': '02:00:00:00:00:01',
+            'dstMac': dut_mac[tg_to_swp[tg_ports[0]]],
+            'srcIp': dev_groups[tg_ports[0]][0]['ip'],
+            'dstIp': routes[-1][0],
+        },
+    }
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    # 2. Add next hop routes
+    out = await IpRoute.add(input_data=[{dent: [
+        {'dst': f'{dst}/{plen}', 'via': link.tg_ip}
+        for dst, plen, link in routes
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add static routes'
+
+    # Send one way traffic from port#0
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # Verify packets received on port#2
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    for row in stats.Rows:
+        loss = tgen_utils_get_loss(row)
+        expected_loss = 0 if row['Rx Port'] == address_map[2].tg else 100
+        assert loss == expected_loss, f'Expected loss: {expected_loss}%, actual: {loss}%'
+
+    # 3. Verify routes offloaded
+    expected_routes = [{'dev': info.swp,
+                        'dst': info.swp_ip[:-1] + f'/{info.plen}',
+                        'flags': ['rt_trap']}
+                       for info in address_map]
+    expected_routes += [{'dev': link.swp,
+                         'dst': dst + (f'/{plen}' if plen != 128 else ''),
+                         'flags': ['offload', 'rt_offload']}
+                        for dst, plen, link in routes]
+    await verify_dut_routes(dent, expected_routes)
+
+    # 4. Remove next hop route
+    out = await IpRoute.delete(input_data=[{dent: [
+        {'dst': f'{dst}/{plen}', 'via': link.tg_ip}
+        for dst, plen, link in (routes[-1],)
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to remove static route'
+
+    # Send one way traffic
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # Verify packets received on port#1
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    for row in stats.Rows:
+        loss = tgen_utils_get_loss(row)
+        expected_loss = 0 if row['Rx Port'] == address_map[1].tg else 100
+        assert loss == expected_loss, f'Expected loss: {expected_loss}%, actual: {loss}%'
+
+    # 5. Verify routes offloaded
+    expected_routes.pop()
+    await verify_dut_routes(dent, expected_routes)
+
+    # 6. Add next hop routes
+    routes.pop()
+    routes += [(routes[0][0], plen, link)
+               for plen, link in ((80, address_map[1]),
+                                  (100, address_map[2]),
+                                  (120, address_map[3]))]
+    out = await IpRoute.add(input_data=[{dent: [
+        {'dst': f'{dst}/{plen}', 'via': link.tg_ip}
+        for dst, plen, link in routes[1:]  # nexthop #0 is already configured
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add static routes'
+
+    # Send one way traffic
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # Verify packets received on port#3
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    for row in stats.Rows:
+        loss = tgen_utils_get_loss(row)
+        expected_loss = 0 if row['Rx Port'] == address_map[3].tg else 100
+        assert loss == expected_loss, f'Expected loss: {expected_loss}%, actual: {loss}%'
+
+    # 7. Verify routes offloaded
+    routes.pop()
+    expected_routes += [{'dev': link.swp,
+                         'dst': f'{dst}/{plen}',
+                         'flags': ['offload', 'rt_offload']}
+                        for dst, plen, link in routes]
+    await verify_dut_routes(dent, expected_routes)


### PR DESCRIPTION
- test_ipv64_nh_reconfig
- test_ipv64_nh_routes
- test_ipv6_route_default_offload
- test_ipv6_route_lpm

Update cleanup_ip_addrs to support IPv6.
Remove ping/NS from previous IPv6 tests, since it is no longer required.
Update remove_default_gateway fixture to support IPv6.
Update IPv6 utils functions.

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>