### PR TITLE
Add pytest-repeat plugin

### DIFF
--- a/DentOS_Framework/DentOsTestbed/Requirements.txt
+++ b/DentOS_Framework/DentOsTestbed/Requirements.txt
@@ -6,5 +6,6 @@ pexpect
 pytest
 pytest-asyncio
 pytest-html
+pytest-repeat
 ixnetwork_restpy
 pyvis == 0.1.9


### PR DESCRIPTION
Add `pytest-repeat` plugin which gives ability to run test cases specific amount of times instead of running it manually.
 When running test case specify amount of repeats by adding `--count` argument to your command for running test case:
`--count=3` - will rerun test case 3 times.
`--repeat-scope` can be used to override default tests executions order, with one of the next values: session, module, class or function (default). It behaves like a scope of the pytest fixture.