### PR TITLE
Add IPv6 tests

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6.py
@@ -128,6 +128,8 @@ async def test_ipv6_basic_config(testbed):
     # 4. Verify neighbors on DUT
     expected_neis = [{'dev': info.swp,
                       'dst': info.tg_ip,
+                      'should_exist': True,
+                      'offload': True,
                       'states': ['REACHABLE', 'PROBE', 'STALE', 'DELAY']}
                      for info in address_map]
     await verify_dut_neighbors(dent, expected_neis)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6.py
@@ -85,8 +85,16 @@ async def test_ipv6_basic_config(testbed):
     await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
 
     # 2. Verify IP configuration: no errors on IP address adding, connected routes added and offloaded
-    expected_addrs = [(info.swp, info.swp_ip, info.plen) for info in address_map]
-    await verify_dut_addrs(dent, expected_addrs, expect_family=('inet6',))
+    expected_addrs = [
+        {'ifname': info.swp,
+         'should_exist': True,
+         'addr_info': {
+            'family': 'inet6',
+            'local': info.swp_ip,
+            'prefixlen': info.plen}}
+        for info in address_map
+    ]
+    await verify_dut_addrs(dent, expected_addrs)
 
     expected_routes = [{'dev': info.swp,
                         'dst': info.swp_ip[:-1] + f'/{info.plen}',

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6.py
@@ -4,6 +4,8 @@ import pytest
 
 from dent_os_testbed.lib.ip.ip_link import IpLink
 from dent_os_testbed.lib.ip.ip_address import IpAddress
+from dent_os_testbed.lib.ip.ip_neighbor import IpNeighbor
+from dent_os_testbed.lib.os.recoverable_sysctl import RecoverableSysctl
 
 from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_dent_devices_with_tgen,
@@ -24,7 +26,7 @@ from dent_os_testbed.test.test_suite.functional.ipv6.ipv6_utils import (
 
 pytestmark = [
     pytest.mark.suite_functional_ipv6,
-    pytest.mark.usefixtures('cleanup_ip_addrs', 'enable_ipv6_forwarding'),
+    pytest.mark.usefixtures('cleanup_ip_addrs', 'enable_ipv6_forwarding', 'cleanup_sysctl'),
     pytest.mark.asyncio,
 ]
 
@@ -151,3 +153,414 @@ async def test_ipv6_basic_config(testbed):
     for row in stats.Rows:
         loss = tgen_utils_get_loss(row)
         assert loss == 100, f'Expected loss: 100%, actual: {loss}%'
+
+
+async def test_ipv6_flags(testbed):
+    """
+    Test Name: test_ipv6_flags
+    Test Suite: suite_functional_ipv6
+    Test Overview:
+        Verify IPv6 address change, replace, set lifetime
+    Test Procedure:
+    1. Add IP addrs in different subnets using change/replace
+    2. Configure Hosts on TG
+    3. Send bidirectional traffic
+       - Verify no packet losses
+       - Verify ip addresses have 'dynamic' True
+    4. Set preferred timer to zero, valid timer must be non zero
+    5. Send bidirectional traffic
+       - Verify no packet losses
+       - Verify entries with preferred timer equal to zero are deprecated
+    6. Set valid timer to one
+       - Verify ip addresses that were marked as 'deprecated' are deleted
+    7. Flush neighbor entries
+    8. Send bidirectional traffic
+       - Verify packet loss occurs as IP addresses got deleted
+    """
+    num_of_ports = 2
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], num_of_ports)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dent_dev = dent_devices[0]
+    dent = dent_dev.host_name
+    tg_ports = tgen_dev.links_dict[dent][0][:num_of_ports]
+    ports = tgen_dev.links_dict[dent][1][:num_of_ports]
+    addr_info = namedtuple('addr_info', ['swp', 'tg', 'swp_ip', 'tg_ip', 'plen'])
+    traffic_duration = 10
+    wait_for_stats = 5
+
+    address_map = (
+        addr_info(ports[0], tg_ports[0], '2001:1111::1', '2001:1111::2', 64),
+        addr_info(ports[1], tg_ports[1], '2001:2222::1', '2001:2222::2', 64),
+        addr_info(ports[0], tg_ports[0], '2001:3333::1', '2001:3333::2', 64),
+        addr_info(ports[1], tg_ports[1], '2001:4444::1', '2001:4444::2', 64),
+    )
+
+    # 1. Add IP addrs in different subnets using change/replace
+    out = await IpLink.set(input_data=[{dent: [
+        {'device': port, 'operstate': 'up'} for port in ports
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to set port state UP'
+
+    valid_lft = 960
+    preferred_lft = 900
+    out = await IpAddress.change(input_data=[{dent: [
+        {'dev': address_map[0].swp,
+         'prefix': f'{address_map[0].swp_ip}/{address_map[0].plen}',
+         'valid_lft': valid_lft,
+         'preferred_lft': preferred_lft},
+        {'dev': address_map[1].swp,
+         'prefix': f'{address_map[1].swp_ip}/{address_map[1].plen}'},
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    out = await IpAddress.replace(input_data=[{dent: [
+        {'dev': address_map[2].swp,
+         'prefix': f'{address_map[2].swp_ip}/{address_map[2].plen}'},
+        {'dev': address_map[3].swp,
+         'prefix': f'{address_map[3].swp_ip}/{address_map[3].plen}',
+         'valid_lft': valid_lft,
+         'preferred_lft': preferred_lft},
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    expected_addrs = [
+        {'ifname': info.swp,
+         'should_exist': True,
+         'addr_info': {
+            'family': 'inet6',
+            'local': info.swp_ip,
+            'dynamic': True if info == address_map[0] or info == address_map[3] else None,
+            'prefixlen': info.plen}}
+        for info in address_map
+    ]
+    await verify_dut_addrs(dent, expected_addrs)
+
+    # 2. Configure Hosts on TG
+    dev_groups = tgen_utils_dev_groups_from_config(
+        {'ixp': info.tg, 'ip': info.tg_ip, 'gw': info.swp_ip,
+         'plen': info.plen, 'version': 'ipv6'}
+        for info in address_map
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    # 3. Send bidirectional traffic
+    streams = {
+        f'{tg_ports[0]} <-> {tg_ports[1]}': {
+            'type': 'ipv6',
+            'ip_source': [ep['name'] for ep in dev_groups[tg_ports[0]]],
+            'ip_destination': [ep['name'] for ep in dev_groups[tg_ports[1]]],
+            'rate': 10000,  # pps
+            'bi_directional': True,
+        },
+    }
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # Verify no packet losses
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    for row in stats.Rows:
+        loss = tgen_utils_get_loss(row)
+        assert loss == 0, f'Expected loss: 0%, actual: {loss}%'
+
+    # Verify ip addresses have 'dynamic' True
+    await verify_dut_addrs(dent, expected_addrs)
+
+    # 4. Set preferred timer to zero, valid timer must be non zero
+    valid_lft = 120
+    preferred_lft = 0
+    out = await IpAddress.change(input_data=[{dent: [
+        {'dev': address_map[0].swp,
+         'prefix': f'{address_map[0].swp_ip}/{address_map[0].plen}',
+         'valid_lft': valid_lft,
+         'preferred_lft': preferred_lft},
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    out = await IpAddress.replace(input_data=[{dent: [
+        {'dev': address_map[3].swp,
+         'prefix': f'{address_map[3].swp_ip}/{address_map[3].plen}',
+         'valid_lft': valid_lft,
+         'preferred_lft': preferred_lft},
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    # 5. Send bidirectional traffic
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # Verify no packet losses
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    for row in stats.Rows:
+        loss = tgen_utils_get_loss(row)
+        assert loss == 0, f'Expected loss: 0%, actual: {loss}%'
+
+    # Verify entries with preferred timer equal to zero are deprecated
+    expected_addrs = [
+        {'ifname': info.swp,
+         'should_exist': True,
+         'addr_info': {
+            'family': 'inet6',
+            'local': info.swp_ip,
+            'dynamic': True if info == address_map[0] or info == address_map[3] else None,
+            'deprecated': True if info == address_map[0] or info == address_map[3] else None,
+            'prefixlen': info.plen}}
+        for info in address_map
+    ]
+    await verify_dut_addrs(dent, expected_addrs)
+
+    # 6. Set valid timer to one
+    valid_lft = 1
+    preferred_lft = 0
+    out = await IpAddress.change(input_data=[{dent: [
+        {'dev': address_map[0].swp,
+         'prefix': f'{address_map[0].swp_ip}/{address_map[0].plen}',
+         'valid_lft': valid_lft,
+         'preferred_lft': preferred_lft},
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    out = await IpAddress.replace(input_data=[{dent: [
+        {'dev': address_map[3].swp,
+         'prefix': f'{address_map[3].swp_ip}/{address_map[3].plen}',
+         'valid_lft': valid_lft,
+         'preferred_lft': preferred_lft},
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    # Verify ip addresses that were marked as 'deprecated' are deleted
+    await asyncio.sleep(5)
+    expected_addrs = [
+        {'ifname': info.swp,
+         'should_exist': info == address_map[1] or info == address_map[2],
+         'addr_info': {
+            'family': 'inet6',
+            'local': info.swp_ip,
+            'prefixlen': info.plen}}
+        for info in address_map
+    ]
+    await verify_dut_addrs(dent, expected_addrs)
+
+    # 7. Flush neighbor entries
+    out = await IpNeighbor.flush(input_data=[{dent: [
+        {'device': port} for port in ports * 2  # flush twice
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to flush neighbors'
+
+    # 8. Send bidirectional traffic
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # Verify packet loss occurs as IP addresses got deleted
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    for row in stats.Rows:
+        loss = tgen_utils_get_loss(row)
+        # some packet loss is expected
+        assert loss >= 99, f'Expected loss: 100%, actual: {loss}%'
+
+
+async def test_ipv6_secondary_addr(testbed):
+    """
+    Test Name: test_ipv6_secondary_addr
+    Test Suite: suite_functional_ipv6
+    Test Overview:
+        Verify DUT link local address sends requests and responds to ICMPv6 echo requests
+        Verify packets with link local IPv6 addresses not routed
+        Verify link local address available, pingable after port down/up
+    Test Procedure:
+    1. Set ports up. Increase base_reachable_time_ms
+    2. Add IP addrs
+       - Verify no errors on IP address adding
+       - Verify connected routes added and offloaded
+    3. Send traffic
+       - Verify neighbor resolved
+       - Verify clear traffic
+    4. Delete first secondary IP addresses on DUT
+    5. Send traffic
+       - Verify IP addresses are deleted
+       - Verify traffic after secondary IP addresses are deleted
+    6. Delete other secondary and primary (in this order) IP addresses on DUT
+    7. Send traffic
+       - Verify IP addresses are deleted
+       - Verify no traffic as IP addresses are deleted
+    8. Add primary and secondary IPv4 addresses back for two DUT ports
+       - Verify IP addresses are added
+       - Verify traffic for primary and secondary IP addresses
+    """
+    num_of_ports = 2
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], num_of_ports)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dent_dev = dent_devices[0]
+    dent = dent_dev.host_name
+    tg_ports = tgen_dev.links_dict[dent][0][:num_of_ports]
+    ports = tgen_dev.links_dict[dent][1][:num_of_ports]
+    addr_info = namedtuple('addr_info', ['swp', 'tg', 'swp_ip', 'tg_ip', 'plen'])
+    traffic_duration = 10
+    wait_for_stats = 5
+    base_reach_time_s = 150
+
+    address_map = (
+        # primary
+        addr_info(ports[0], tg_ports[0], '2001:1111::1', '2001:1111::2', 64),
+        addr_info(ports[1], tg_ports[1], '2001:2222::1', '2001:2222::2', 64),
+        # secondary 1
+        addr_info(ports[0], tg_ports[0], '2001:1111::3', '2001:1111::4', 64),
+        addr_info(ports[1], tg_ports[1], '2001:2222::3', '2001:2222::4', 64),
+        # secondary 2
+        addr_info(ports[0], tg_ports[0], '2001:1111::5', '2001:1111::6', 64),
+        addr_info(ports[1], tg_ports[1], '2001:2222::5', '2001:2222::6', 64),
+    )
+    config = {
+        f'net.ipv6.neigh.{ports[0]}.base_reachable_time_ms': base_reach_time_s * 1000,
+        f'net.ipv6.neigh.{ports[1]}.base_reachable_time_ms': base_reach_time_s * 1000,
+    }
+
+    # 1. Increase base_reachable_time_ms
+    out = await RecoverableSysctl.set(input_data=[{dent: [
+        {'variable': variable, 'value': value}
+        for variable, value in config.items()
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to update sysctl values'
+
+    # Set ports up
+    out = await IpLink.set(input_data=[{dent: [
+        {'device': port, 'operstate': 'up'} for port in ports
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to set port state UP'
+
+    # 2. Add IP addrs
+    out = await IpAddress.add(input_data=[{dent: [
+        {'dev': info.swp, 'prefix': f'{info.swp_ip}/{info.plen}'}
+        for info in address_map
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        {'ixp': info.tg, 'ip': info.tg_ip, 'gw': info.swp_ip,
+         'plen': info.plen, 'version': 'ipv6'}
+        for info in address_map
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    # Verify no errors on IP address adding
+    expected_addrs = [
+        {'ifname': info.swp,
+         'should_exist': True,
+         'addr_info': {
+            'family': 'inet6',
+            'local': info.swp_ip,
+            'prefixlen': info.plen}}
+        for info in address_map
+    ]
+    await verify_dut_addrs(dent, expected_addrs)
+
+    # Verify connected routes added and offloaded
+    expected_routes = [
+        {'dev': info.swp,
+         'dst': info.swp_ip[:-1] + f'/{info.plen}',
+         'should_exist': True,
+         'flags': ['rt_trap']}
+        for info in address_map
+    ]
+    await verify_dut_routes(dent, expected_routes)
+
+    # 3. Send traffic
+    streams = {
+        f"{src['name']} <-> {dst['name']}": {
+            'type': 'ipv6',
+            'ip_source': src['name'],
+            'ip_destination': dst['name'],
+            'rate': 10000,  # pps
+            'bi_directional': True,
+        } for src, dst in zip(dev_groups[tg_ports[0]], dev_groups[tg_ports[1]])
+    }
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # Verify clear traffic
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    assert all(tgen_utils_get_loss(row) == 0 for row in stats.Rows), 'Unexpected traffic loss'
+
+    # Verify neighbor resolved
+    expected_neis = [{'dev': info.swp,
+                      'dst': info.tg_ip,
+                      'should_exist': True,
+                      'offload': True,
+                      'states': ['REACHABLE']}
+                     for info in address_map]
+    await verify_dut_neighbors(dent, expected_neis)
+
+    # 4. Delete first secondary IP addresses on DUT
+    out = await IpAddress.delete(input_data=[{dent: [
+        {'dev': info.swp, 'prefix': f'{info.swp_ip}/{info.plen}'}
+        for info in address_map[2:4]
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    # 5. Send traffic
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # Verify IP addresses are deleted
+    [addr.update({'should_exist': False}) for addr in expected_addrs[2:4]]
+    await verify_dut_addrs(dent, expected_addrs)
+
+    # Verify traffic after secondary IP addresses are deleted
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    assert all(tgen_utils_get_loss(row) == 0 for row in stats.Rows), 'Unexpected traffic loss'
+
+    # 6. Delete other secondary and primary (in this order) IP addresses on DUT
+    out = await IpAddress.delete(input_data=[{dent: [
+        {'dev': info.swp, 'prefix': f'{info.swp_ip}/{info.plen}'}
+        for info in address_map[4:] + address_map[:2]
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    # 7. Send traffic
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # Verify IP addresses are deleted
+    [addr.update({'should_exist': False}) for addr in expected_addrs]
+    await verify_dut_addrs(dent, expected_addrs)
+
+    # Verify no traffic as IP addresses are deleted
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    assert all(tgen_utils_get_loss(row) == 100 for row in stats.Rows), 'Unexpected traffic'
+
+    # 8. Add primary and secondary IPv4 addresses back for two DUT ports
+    out = await IpAddress.add(input_data=[{dent: [
+        {'dev': info.swp, 'prefix': f'{info.swp_ip}/{info.plen}'}
+        for info in address_map
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    # Verify IP addresses are added
+    [addr.update({'should_exist': True}) for addr in expected_addrs]
+    await verify_dut_addrs(dent, expected_addrs)
+
+    # Verify traffic for primary and secondary IP addresses
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    assert all(tgen_utils_get_loss(row) == 0 for row in stats.Rows), 'Unexpected traffic loss'

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_bridge.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_bridge.py
@@ -135,6 +135,8 @@ async def test_ipv6_on_bridge(testbed):
     # 5. Verify neighbors resolved
     expected_neis = [{'dev': info.swp,
                       'dst': info.tg_ip,
+                      'should_exist': True,
+                      'offload': True,
                       'states': ['REACHABLE', 'PROBE', 'STALE', 'DELAY']}
                      for info in address_map]
     await verify_dut_neighbors(dent, expected_neis)
@@ -355,6 +357,8 @@ async def test_ipv6_move_host_on_bridge(testbed):
     # 4. Verify neighbors resolved
     expected_neis = [{'dev': info.swp,
                       'dst': info.tg_ip,
+                      'should_exist': True,
+                      'offload': True,
                       'states': ['REACHABLE', 'PROBE', 'STALE', 'DELAY']}
                      for info in address_map]
     learned_macs = await verify_dut_neighbors(dent, expected_neis)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_ipv4.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_ipv4.py
@@ -190,10 +190,14 @@ async def test_ipv64_nh_reconfig(testbed):
 
         expected_neis = [{'dev': info.swp,
                           'dst': info.tg_ip,
+                          'should_exist': True,
+                          'offload': True,
                           'states': ['REACHABLE', 'PROBE', 'STALE', 'DELAY']}
                          for info in address_map[version]]
         expected_neis += [{'dev': nh_route[version].swp,
                            'dst': nh_route[version].via,
+                           'should_exist': True,
+                           'offload': True,
                            'states': ['PERMANENT']}]
         await verify_dut_neighbors(dent, expected_neis)
 
@@ -368,10 +372,14 @@ async def test_ipv64_nh_routes(testbed):
     # 6. Verify neighbors resolved
     expected_neis = [{'dev': info.swp,
                       'dst': info.tg_ip,
+                      'should_exist': True,
+                      'offload': True,
                       'states': ['REACHABLE', 'PROBE', 'STALE', 'DELAY']}
                      for info in address_map]
     expected_neis += [{'dev': route.swp,
                        'dst': route.via,
+                       'should_exist': True,
+                       'offload': True,
                        'states': ['PERMANENT']}
                       for route in nh_route]
     await verify_dut_neighbors(dent, expected_neis)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_nei.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_nei.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 import asyncio
 import pytest
+import random
 import time
 
 from dent_os_testbed.lib.ip.ip_link import IpLink
@@ -12,7 +13,11 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_dent_devices_with_tgen,
     tgen_utils_traffic_generator_connect,
     tgen_utils_dev_groups_from_config,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_start_traffic,
     tgen_utils_setup_streams,
+    tgen_utils_stop_traffic,
+    tgen_utils_get_loss,
     tgen_utils_send_ns,
 )
 
@@ -21,7 +26,9 @@ from dent_os_testbed.utils.test_utils.tb_utils import (
 )
 
 from dent_os_testbed.test.test_suite.functional.ipv6.ipv6_utils import (
+    verify_dut_neighbors,
     verify_dut_routes,
+    verify_dut_addrs,
 )
 
 pytestmark = [
@@ -306,3 +313,259 @@ async def test_ipv6_nei_ageing(testbed):
     assert elapsed < expected_time, \
         f'Expected neighbors to be aged after no more than {expected_time}s, ' + \
         f'but waited for {elapsed // 1}s'
+
+
+async def test_ipv6_nei_change(testbed):
+    """
+    Test Name: test_ipv6_nei_change
+    Test Suite: suite_functional_ipv6
+    Test Overview:
+        Verify neighbor entries modification, delete and flush
+    Test Procedure:
+    1. Add IP addrs, configure hosts on TG
+       - Verify IP addresses added
+       - Verify routes created
+    2. Configure protocol interfaces on TG
+    3. Send bidirectional traffic between TG hosts
+       - Verify neighbor on DUT
+    4. Change neighbor nud state to permanent
+       - Verify nud change
+       - Verify its not stale after timeout
+       - Verify neighbor entries have been offloaded
+    5. Change neighbor nud state to reachable
+       - Verify neighbor nud change
+       - Verify entries will change nud state to stale after timeout
+    6. Add two permanent neighbor entries and two stale neighbor entries
+       - Verify neighbor entries were added successfully
+    7. Flush specific entries by prefix and state
+       - Verify all entries by prefix and nud state are flushed,
+         except entries that do not fit by prefix and nud state
+    8. Initiate neighbor from TG to restore entries
+    9. Delete one permanent and one dynamic entry
+       - Verify neighbor entries are deleted
+    """
+    num_of_ports = 2
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], num_of_ports)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dent_dev = dent_devices[0]
+    dent = dent_dev.host_name
+    tg_ports = tgen_dev.links_dict[dent][0][:num_of_ports]
+    ports = tgen_dev.links_dict[dent][1][:num_of_ports]
+    addr_info = namedtuple('addr_info', ['swp', 'tg', 'swp_ip', 'tg_ip', 'plen'])
+    traffic_duration = 10
+    wait_for_stats = 5
+    gc_interval_s = 15
+    gc_thresh = 20
+    nei_update_time_s = 5
+    base_reach_time_s = 35
+
+    address_map = (
+        addr_info(ports[0], tg_ports[0], '2001:1111::1', '2001:1111::2', 64),
+        addr_info(ports[1], tg_ports[1], '2001:2222::1', '2001:2222::2', 64),
+    )
+    config = {
+        'net.ipv6.neigh.default.gc_interval': gc_interval_s,
+        'net.ipv6.neigh.default.gc_thresh1': gc_thresh,
+        'net.ipv6.neigh.default.base_reachable_time_ms': base_reach_time_s * 1000,
+        'net.ipv6.neigh.default.delay_first_probe_time': nei_update_time_s,
+    }
+
+    out = await RecoverableSysctl.set(input_data=[{dent: [
+        {'variable': variable, 'value': value}
+        for variable, value in config.items() if 'gc_thresh' not in variable
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to update sysctl values'
+
+    # 1. Add IP addrs, configure hosts on TG
+    out = await IpLink.set(input_data=[{dent: [
+        {'device': port, 'operstate': 'up'} for port in ports
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to set port state UP'
+
+    out = await IpAddress.add(input_data=[{dent: [
+        {'dev': info.swp, 'prefix': f'{info.swp_ip}/{info.plen}'}
+        for info in address_map
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add IP addr to port'
+
+    # Verify IP addresses added
+    expected_addrs = [
+        {'ifname': info.swp,
+         'should_exist': True,
+         'addr_info': {
+            'family': 'inet6',
+            'local': info.swp_ip,
+            'prefixlen': info.plen}}
+        for info in address_map
+    ]
+    await verify_dut_addrs(dent, expected_addrs)
+
+    # Verify routes created
+    expected_routes = [
+        {'dev': info.swp,
+         'dst': info.swp_ip[:-1] + f'/{info.plen}',
+         'should_exist': True,
+         'flags': ['rt_trap']}
+        for info in address_map
+    ]
+    await verify_dut_routes(dent, expected_routes)
+
+    # 2. Configure protocol interfaces on TG
+    dev_groups = tgen_utils_dev_groups_from_config(
+        {'ixp': info.tg, 'ip': info.tg_ip, 'gw': info.swp_ip,
+         'plen': info.plen, 'version': 'ipv6'}
+        for info in address_map
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    # 3. Send bidirectional traffic between TG hosts
+    await tgen_utils_setup_streams(tgen_dev, None, {'dummy': {'type': 'ipv6'}})
+
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    await asyncio.sleep(wait_for_stats)
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Flow Statistics')
+    assert all(tgen_utils_get_loss(row) == 0 for row in stats.Rows), 'Unexpected traffic loss'
+
+    # Verify neighbor on DUT
+    expected_neis = [
+        {'dev': info.swp,
+         'dst': info.tg_ip,
+         'should_exist': True,
+         'offload': True,
+         'states': ['REACHABLE', 'STALE']}
+        for info in address_map
+    ]
+    await wait_for_nei_state(dent_dev, expected_neis, poll_interval=nei_update_time_s)
+
+    # 4. Change neighbor nud state to permanent
+    out = await IpNeighbor.show(input_data=[{dent: [
+        {'cmd_options': '-j -6'}
+    ]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0, 'Failed to get DUT neighbors'
+
+    dut_nei = {
+        nei['dev']: {'ip': nei['dst'], 'lladdr': nei['lladdr']}
+        for nei in out[0][dent]['parsed_output']
+        if nei['dev'] in ports and not nei['dst'].startswith('f')
+    }
+
+    out = await IpNeighbor.change(input_data=[{dent: [
+        {'dev': dev, 'lladdr': nei['lladdr'], 'address': nei['ip'], 'nud': 'permanent'}
+        for dev, nei in dut_nei.items()
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to update DUT neighbors'
+
+    # Verify nud change
+    [nei.update({'states': ['PERMANENT']}) for nei in expected_neis]
+    await verify_dut_neighbors(dent, expected_neis)
+
+    # Verify its not stale after timeout
+    dent_dev.applog.info('Waiting for neighbor state to change')
+    await asyncio.sleep(base_reach_time_s*1.5 + nei_update_time_s*2)
+
+    # Verify neighbor entries have been offloaded
+    await verify_dut_neighbors(dent, expected_neis)
+
+    # 5. Change neighbor nud state to reachable
+    out = await IpNeighbor.change(input_data=[{dent: [
+        {'dev': dev, 'lladdr': nei['lladdr'], 'address': nei['ip'], 'nud': 'reachable'}
+        for dev, nei in dut_nei.items()
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to update DUT neighbors'
+
+    # Verify neighbor nud change
+    [nei.update({'states': ['REACHABLE']}) for nei in expected_neis]
+    await verify_dut_neighbors(dent, expected_neis)
+
+    # Verify entries will change nud state to stale after timeout
+    [nei.update({'states': ['STALE']}) for nei in expected_neis]
+    await wait_for_nei_state(dent_dev, expected_neis)
+
+    # 6. Add two permanent neighbor entries and two stale neighbor entries
+    rand_ip = [info.tg_ip[:-1] + f'{idx + 1:x}:{random.randint(0xf, 0xfff0):x}'
+               for idx, info in enumerate(address_map + address_map)]
+    rand_mac = [f'02:00:00:00:{idx:02x}:{random.randint(1, 255):02x}' for idx in range(4)]
+    nei_state = ['permanent', 'permanent', 'stale', 'stale']
+
+    out = await IpNeighbor.add(input_data=[{dent: [
+        {'dev': dev, 'lladdr': lladdr, 'address': ip, 'nud': state}
+        for dev, ip, lladdr, state in zip(ports + ports, rand_ip, rand_mac, nei_state)
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to update DUT neighbors'
+
+    # Verify neighbor entries were added successfully
+    expected_neis += [
+        {'dev': dev,
+         'dst': ip,
+         'lladdr': lladdr,
+         'should_exist': True,
+         'offload': True,
+         'states': [state.upper()]}
+        for dev, ip, lladdr, state in zip(ports + ports, rand_ip, rand_mac, nei_state)
+    ]
+    await verify_dut_neighbors(dent, expected_neis)
+
+    # 7. Flush specific entries by prefix and state
+    out = await IpNeighbor.flush(input_data=[{dent: [
+        {'dev': address_map[0].swp,
+         'address': address_map[0].swp_ip[:-1] + f'/{address_map[0].plen}',  # 2001:1111::/64
+         'nud': 'permanent'},
+        {'dev': address_map[1].swp,
+         'address': address_map[1].swp_ip[:-1] + f'/{address_map[1].plen}'},  # 2001:2222::/64
+    ] * 2  # flush twice
+    }])
+    assert out[0][dent]['rc'] == 0, 'Failed to update DUT neighbors'
+
+    # Verify all entries by prefix and nud state are flushed,
+    # except entries that do not fit by prefix and nud state
+    expected_neis = [
+        {'dev': info.swp,
+         'dst': info.tg_ip,
+         'should_exist': info.swp == address_map[0].swp,
+         'offload': True,
+         'states': ['STALE']}
+        for info in address_map
+    ]
+    expected_neis += [
+        {'dev': dev,
+         'dst': ip,
+         'lladdr': lladdr,
+         'should_exist': ip == rand_ip[1] or ip == rand_ip[2],
+         'offload': True,
+         'states': [state.upper()]}
+        for dev, ip, lladdr, state in zip(ports + ports, rand_ip, rand_mac, nei_state)
+    ]
+    await verify_dut_neighbors(dent, expected_neis)
+
+    # 8. Initiate neighbor from TG to restore entries
+    out = await tgen_utils_send_ns(tgen_dev, ({'ixp': tg} for tg in tg_ports))
+    assert all(rc['success'] for rc in out), 'Failed to send NS from TG'
+
+    # 9. Delete one permanent and one dynamic entry
+    out = await IpNeighbor.delete(input_data=[{dent: [
+        {'dev': dev, 'address': ip, 'lladdr': lladdr, 'nud': state}
+        for dev, ip, lladdr, state in zip(ports[::-1], rand_ip[1:3], rand_mac[1:3], nei_state[1:3])
+    ]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to update DUT neighbors'
+
+    # Verify neighbor entries are deleted
+    expected_neis = [
+        {'dev': info.swp,
+         'dst': info.tg_ip,
+         'should_exist': True,
+         'offload': True,
+         'states': ['REACHABLE', 'STALE']}
+        for info in address_map
+    ]
+    expected_neis += [
+        {'dev': dev,
+         'dst': ip,
+         'lladdr': lladdr,
+         'should_exist': False}
+        for dev, ip, lladdr in zip(ports + ports, rand_ip, rand_mac)
+    ]
+    await wait_for_nei_state(dent_dev, expected_neis, timeout=base_reach_time_s)


### PR DESCRIPTION
Add new tests:
- test_ipv6_flags
- test_ipv6_secondary_addr
- test_ipv6_nei_change

Fix the previous test:
- test_ipv6_nei_ageing

Make utils functions more generic:
- verify_dut_addrs
- verify_dut_neighbors
- wait_for_nei_state

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>