### PR TITLE
Skip L1 tests on unsupported device

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/L1/test_l1_autodetect.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/L1/test_l1_autodetect.py
@@ -62,7 +62,10 @@ async def test_l1_autodetect(testbed, speed, duplex):
     device_host_name = dent_dev.host_name
     tg_ports = tgen_dev.links_dict[device_host_name][0]
     ports = tgen_dev.links_dict[device_host_name][1][:2]
-    speed_ports = await tb_get_qualified_ports(dent_dev, ports, speed, duplex)
+    try:
+        speed_ports = await tb_get_qualified_ports(dent_dev, ports, speed, duplex)
+    except ValueError as e:
+        pytest.skip(str(e))
 
     # 1. Create bridge entity
     out = await IpLink.add(input_data=[{device_host_name: [{'device': 'br0', 'type': 'bridge'}]}])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/L1/test_l1_autoneg.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/L1/test_l1_autoneg.py
@@ -69,7 +69,10 @@ async def test_l1_autoneg(testbed, speed, duplex):
         '1000_full': '0x020',
         '10000_full': '0x1000'
     }
-    speed_ports = await tb_get_qualified_ports(dent_dev, ports, speed, duplex)
+    try:
+        speed_ports = await tb_get_qualified_ports(dent_dev, ports, speed, duplex)
+    except ValueError as e:
+        pytest.skip(str(e))
 
     # 1. Create bridge entity
     out = await IpLink.add(input_data=[{device_host_name: [{'device': 'br0', 'type': 'bridge'}]}])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/L1/test_l1_config.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/L1/test_l1_config.py
@@ -4,6 +4,7 @@ import asyncio
 from dent_os_testbed.lib.ip.ip_link import IpLink
 from dent_os_testbed.lib.ethtool.ethtool import Ethtool
 
+from dent_os_testbed.utils.test_utils.tb_utils import tb_get_qualified_ports
 from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_dent_devices_with_tgen,
     tgen_utils_dev_groups_from_config,
@@ -42,6 +43,10 @@ async def test_l1_settings_(testbed, l1_settings):
     speed = 1000
     duplex = 'full'
     advertise = '0x020'
+    try:
+        await tb_get_qualified_ports(dent_devices[0], tgen_dev.links_dict[device_host_name][1], speed, duplex, required_ports=1)
+    except ValueError as e:
+        pytest.skip(str(e))
 
     options = {
         'autodetect':

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/L1/test_l1_forced_speed.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/L1/test_l1_forced_speed.py
@@ -63,7 +63,10 @@ async def test_l1_forced_speed_(testbed, speed, duplex):
     tg_ports = tgen_dev.links_dict[device_host_name][0]
     ports = tgen_dev.links_dict[device_host_name][1][:2]
 
-    speed_ports = await tb_get_qualified_ports(dent_dev, ports, speed, duplex)
+    try:
+        speed_ports = await tb_get_qualified_ports(dent_dev, ports, speed, duplex)
+    except ValueError as e:
+        pytest.skip(str(e))
 
     # 1. Create bridge entity
     out = await IpLink.add(input_data=[{device_host_name: [{'device': 'br0', 'type': 'bridge'}]}])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/L1/test_l1_mixed_speed.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/L1/test_l1_mixed_speed.py
@@ -4,6 +4,7 @@ import asyncio
 from dent_os_testbed.lib.ip.ip_link import IpLink
 from dent_os_testbed.lib.ethtool.ethtool import Ethtool
 
+from dent_os_testbed.utils.test_utils.tb_utils import tb_get_qualified_ports
 from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_dent_devices_with_tgen,
     tgen_utils_traffic_generator_connect,
@@ -58,6 +59,11 @@ async def test_l1_mixed_speed(testbed):
     tg_ports = tgen_dev.links_dict[device_host_name][0]
     ports = tgen_dev.links_dict[device_host_name][1]
     timeout = 10
+    try:
+        for speed, duplex in ((10, 'full'), (100, 'half'), (1000, 'full')):
+            await tb_get_qualified_ports(dent_devices[0], ports, speed, duplex, required_ports=1)
+    except ValueError as e:
+        pytest.skip(str(e))
 
     # 1. Init bridge entity br0.
     out = await IpLink.add(input_data=[{device_host_name: [{'device': bridge, 'type': 'bridge'}]}])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tb_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tb_utils.py
@@ -585,7 +585,8 @@ async def tb_get_qualified_ports(device, ports, speed, duplex, required_ports=2)
             speed_ports[port] = {'speed': speed,
                                  'duplex': duplex}
     err_msg = f'Need {required_ports} ports with the same speed of {speed} and duplex {duplex}'
-    assert len(speed_ports) >= required_ports, err_msg
+    if len(speed_ports) < required_ports:
+        raise ValueError(err_msg)
     return speed_ports
 
 


### PR DESCRIPTION
Several L1 tests can not be run on devices depending on ports' supported link speeds. Added the mechanism to skip the test if it does not match the device requirements.