### PR TITLE
Add VRRP tests

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/constants.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/constants.py
@@ -86,6 +86,7 @@ PYTEST_SUITES = {
     'suite_functional_table_size': 'Table size functional tests',
     'suite_functional_lacp': 'LACP functional tests',
     'suite_functional_vrrp': 'VRRP functional tests',
+    'suite_functional_ecmp': 'Ecmp functional tests',
 }
 
 PYTEST_SUITE_GROUPS = {
@@ -137,5 +138,6 @@ PYTEST_SUITE_GROUPS = {
         'suite_functional_table_size',
         'suite_functional_lacp',
         'suite_functional_vrrp',
+        'suite_functional_ecmp',
     ]
 }

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/constants.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/constants.py
@@ -85,6 +85,7 @@ PYTEST_SUITES = {
     'suite_functional_hard_drop_counters': 'Hard Drop counters functional tests',
     'suite_functional_table_size': 'Table size functional tests',
     'suite_functional_lacp': 'LACP functional tests',
+    'suite_functional_vrrp': 'VRRP functional tests',
 }
 
 PYTEST_SUITE_GROUPS = {
@@ -135,5 +136,6 @@ PYTEST_SUITE_GROUPS = {
         'suite_functional_hard_drop_counters',
         'suite_functional_table_size',
         'suite_functional_lacp',
+        'suite_functional_vrrp',
     ]
 }

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/conftest.py
@@ -175,7 +175,8 @@ async def cleanup_vrfs(testbed):
 @pytest_asyncio.fixture
 async def cleanup_ip_addrs(testbed):
     yield
-    tgen_dev, devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    # get all dent devices regardless of number of tg links
+    tgen_dev, devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 0)
     ip_addrs_cleanups = [_cleanup_ip_addrs(dev, tgen_dev) for dev in devices]
     await asyncio.gather(*ip_addrs_cleanups)
 
@@ -207,6 +208,7 @@ async def cleanup_sysctl():
 @pytest_asyncio.fixture
 async def cleanup_bonds(testbed):
     yield
-    _, devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    # get all dent devices regardless of number of tg links
+    _, devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 0)
     bonds_cleanup = [_cleanup_bonds(dev) for dev in devices]
     await asyncio.gather(*bonds_cleanup)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ecmp/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ecmp/conftest.py
@@ -1,0 +1,45 @@
+import pytest
+import pytest_asyncio
+
+
+from dent_os_testbed.utils.test_utils.tgen_utils import tgen_utils_get_dent_devices_with_tgen
+from dent_os_testbed.utils.test_utils.cleanup_utils import cleanup_sysctl
+from dent_os_testbed.lib.os.recoverable_sysctl import RecoverableSysctl
+
+
+@pytest_asyncio.fixture()
+async def enable_ignore_linkdown_routes(testbed):
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dent = dent_devices[0].host_name
+    ignore_routes = 'net.ipv4.conf.default.ignore_routes_with_linkdown'
+
+    out = await RecoverableSysctl.set(input_data=[{dent: [
+        {'variable': ignore_routes, 'value': 1}
+    ]}])
+    assert not out[0][dent]['rc'], f'Failed to set net.ipv4.conf.default.ignore_routes_with_linkdown=1 \n{out}'
+
+    yield
+
+    # Restore original value
+    await cleanup_sysctl()
+
+
+@pytest_asyncio.fixture()
+async def enable_multipath_hash_policy(testbed):
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dent = dent_devices[0].host_name
+    multipath_hash_policy = 'net.ipv4.fib_multipath_hash_policy'
+
+    out = await RecoverableSysctl.set(input_data=[{dent: [
+        {'variable': multipath_hash_policy, 'value': 1}
+    ]}])
+    assert not out[0][dent]['rc'], f'Failed to set net.ipv4.fib_multipath_hash_policy=1 \n{out}'
+
+    yield
+
+    # Restore original value
+    await cleanup_sysctl()

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ecmp/test_ecmp.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ecmp/test_ecmp.py
@@ -1,0 +1,527 @@
+import math
+import asyncio
+import pytest
+from random import randint
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+from dent_os_testbed.lib.ip.ip_neighbor import IpNeighbor
+from dent_os_testbed.lib.ip.ip_route import IpRoute
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_setup_streams,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
+    tgen_utils_get_swp_info,
+    tgen_utils_clear_traffic_stats,
+)
+
+pytestmark = [pytest.mark.suite_functional_ecmp,
+              pytest.mark.asyncio,
+              pytest.mark.usefixtures('cleanup_ip_addrs', 'cleanup_tgen', 'enable_ipv4_forwarding')]
+
+RX_STATS = 'Valid Frames Rx.'
+ERR_MSG = 'Expected Rx amount of pkts on port {} to be 0 actual results {}'
+DEVIATION_PKTS = 50
+
+
+def random_mac():
+    return ':'.join(['02'] + [f'{randint(0, 255):02x}' for _ in range(5)])
+
+
+async def verify_ecmp_distribution(stats, tx_port, rx_ports):
+    """
+    Verify Ecmp packet distribution between ports
+    Args:
+        stats: Ixia statistics
+        tx_port (object): Tg Port object
+        rx_ports (list): List with Tg Ports objects
+    """
+    p_err_msg = 'Port {} received pkts {} expected => {}'
+    rx_sum_msg = 'Tx pkts sent {} isnt equal to sum of all rx ports received {}'
+    tx_pkts_sent = [int(row['Frames Tx.']) for row in stats.Rows if row['Port Name'] == tx_port][0]
+    rx_pkts_sum = []
+    # We cant expected that amount of pkts traversed through each nexthop will be equal
+    # Check that at least 1/10 of traffic went through port and verify sum of all rx packets is equal to tx packets
+    expected = tx_pkts_sent // 10
+    for row in stats.Rows:
+        if row['Port Name'] in rx_ports:
+            assert int(row[RX_STATS]) >= expected, p_err_msg.format(row['Port Name'], row[RX_STATS], expected)
+            rx_pkts_sum.append(int(row[RX_STATS]))
+    assert math.isclose(tx_pkts_sent, sum(rx_pkts_sum), rel_tol=0.01), rx_sum_msg.format(tx_pkts_sent, sum(rx_pkts_sum))
+
+
+@pytest.mark.usefixtures('enable_ignore_linkdown_routes')
+@pytest.mark.parametrize('nexthops_down', [1, 3])
+async def test_ecmp_nexthops_down(testbed, nexthops_down):
+    """
+    Test Name: test_ecmp_nexthops_down
+    Test Suite: suite_functional_ecmp
+    Test Overview: Test Ecmp with ignore_routes_with_linkdown sysctl on and simulate 1/3 nexthops down
+    Test Procedure:
+    1. Enable ignore_routes_with_linkdown with fixture
+    2. Configure 4 ports up
+    3. Configure IP addrs on 4 dut ports and connect all devices
+    4. Add static arp entries to last 3 ports (all rx ports)
+    5. Configure Ecmp route to 100.0.0.0/8 with rx ports as nexthops
+    6. Setup ipv4 stream with incremented ip_dst addresses that would distribute through all nexthops
+    7. Configure 1st/all rx_ports down to simulate nexthops down
+    8. Transmit added stream
+    9. Verify traffic distributed through all expected nexthops
+    10. Disable ignore_routes_with_linkdown on teardown with fixture
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    dent_dev = dent_devices[0]
+
+    # 1.Enable net.ipv4.conf.default.ignore_routes_with_linkdown with fixture
+    # 2.Configure 4 ports up
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': port, 'operstate': 'up'} for port in dut_ports]}])
+    err_msg = f"Verify that ports set to 'UP' state.\n{out}"
+    assert not out[0][dev_name]['rc'], err_msg
+
+    # 3.Configure IP addrs on 4 dut ports and connect all devices
+    address_map = (
+        # swp port,    tg port,     swp ip,    tg ip,     plen               lladdr
+        (dut_ports[0], tg_ports[0], '1.1.1.1',  '1.1.1.2',  24, 'aa:bb:cc:dd:ee:11'),
+        (dut_ports[1], tg_ports[1], '11.0.0.1', '11.0.0.2', 8,  '00:AD:20:B2:A7:75'),
+        (dut_ports[2], tg_ports[2], '12.0.0.1', '12.0.0.2', 16, '00:59:CD:1E:83:1B'),
+        (dut_ports[3], tg_ports[3], '13.0.0.1', '13.0.0.2', 20, '00:76:69:89:E0:7B'),
+    )
+    out = await IpAddress.add(input_data=[{dev_name: [
+            {'dev': port, 'prefix': f'{ip}/{plen}'} for port, _, ip, _, plen, _ in address_map]}])
+    assert not out[0][dev_name]['rc'], 'Failed to add IP addr to ports'
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': tg_port, 'ip': tg_ip, 'gw': swp_ip, 'plen': plen}
+         for _, tg_port, swp_ip, tg_ip, plen, _ in address_map])
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+
+    # 4.Add static arp entries to last 3 ports (all rx ports)
+    out = await IpNeighbor.add(input_data=[{dev_name: [
+        {'dev': port, 'address': nei_ip, 'lladdr': lladdr}
+        for port, _, _, nei_ip, _, lladdr in address_map[1:]
+    ]}])
+    assert not out[0][dev_name]['rc'], 'Failed to add static arp entries'
+
+    # 5.Configure Ecmp route to 100.0.0.0/8 with rx ports as nexthops
+    out = await IpRoute.add(input_data=[{dev_name: [
+        {'dst': '100.0.0.0/8', 'nexthop': [
+            {'via': tg_ip, 'weight': 1} for _, _, _, tg_ip, _, _ in address_map[1:]]}
+    ]}])
+    assert not out[0][dev_name]['rc'], 'Failed to add nexthop'
+
+    # 6.Setup ipv4 stream with incremented ip_dst address that would distribute through all nexthops
+    swp_info = {}
+    await tgen_utils_get_swp_info(dent_dev, dut_ports[0], swp_info)
+    stream = {'increment_ip_dst_': {
+        'type': 'raw',
+        'protocol': 'ip',
+        'ip_source': dev_groups[tg_ports[0]][0]['name'],
+        'ip_destination': dev_groups[tg_ports[1]][0]['name'],  # We dont care about ip_dst as we will use port stats
+        'srcMac': random_mac(),
+        'dstMac': swp_info['mac'],
+        'srcIp': f'1.1.1.{randint(3, 100)}',
+        'dstIp': {'type': 'increment',
+                  'start': '100.0.0.1',
+                  'step':  '0.0.0.1',
+                  'count': 30},
+        'frameSize': 200,
+        'rate': 100,
+        'frame_rate_type': 'line_rate'}
+    }
+    await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=stream)
+
+    # 7.Configure 1st/all rx_ports down to simulate nexthops down
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dut_ports[hop], 'operstate': 'down'} for hop in range(1, nexthops_down + 1)]}])
+    err_msg = f"Verify that ports set to 'DOWN' state.\n{out}"
+    assert not out[0][dev_name]['rc'], err_msg
+
+    # 8.Transmit added stream
+    await tgen_utils_clear_traffic_stats(tgen_dev)
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(15)
+    await tgen_utils_stop_traffic(tgen_dev)
+    # Wait 15 sec for stats to be updated
+    await asyncio.sleep(15)
+
+    # 9.Verify traffic distributed through all expected nexthops
+    # 10.Disable ignore_routes_with_linkdown on teardown with fixture
+    stats = await tgen_utils_get_traffic_stats(tgen_dev)
+    if nexthops_down == 1:
+        await verify_ecmp_distribution(stats, tg_ports[0], tg_ports[2:])
+        for row in stats.Rows:
+            if row['Port Name'] == tg_ports[1]:
+                assert int(row[RX_STATS]) <= DEVIATION_PKTS, ERR_MSG.format(row['Port Name'], row[RX_STATS])
+    else:
+        for row in stats.Rows:
+            if row['Port Name'] != tg_ports[0]:
+                assert int(row[RX_STATS]) <= DEVIATION_PKTS, ERR_MSG.format(row['Port Name'], row[RX_STATS])
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dut_ports[hop], 'operstate': 'up'} for hop in range(1, nexthops_down + 1)]}])
+    err_msg = f"Verify that ports set to 'UP' state.\n{out}"
+    assert not out[0][dev_name]['rc'], err_msg
+
+
+@pytest.mark.usefixtures('enable_multipath_hash_policy')
+async def test_ecmp_hash_policy(testbed):
+    """
+    Test Name: test_ecmp_hash_policy
+    Test Suite: suite_functional_ecmp
+    Test Overview: Test Ecmp with fib_multipath_hash_policy on, and hash calculated on L4 (5-tuple)
+    Test Procedure:
+    1. Enable net.ipv4.fib_multipath_hash_policy=1 with fixture
+    2. Configure 4 ports up
+    3. Configure IP addrs on 4 dut ports and connect all devices
+    4. Add static arp entries to last 3 ports (all rx ports)
+    5. Configure Ecmp route to 100.0.0.0/8 with rx ports as nexthops
+    6. Setup 20 streams with identical l2/l3 info but random tcp dst/src ports value to 100.0.0.0/8 network
+    7. Transmit all streams and wait streams to finish
+    8. Verify traffic distributed through all expected nexthops
+    9. Disable net.ipv4.fib_multipath_hash_policy on teardown with fixture
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    dent_dev = dent_devices[0]
+
+    # 1.Enable net.ipv4.fib_multipath_hash_policy=1 with fixture
+    # 2.Configure 4 ports up
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': port, 'operstate': 'up'} for port in dut_ports]}])
+    err_msg = f"Verify that ports set to 'UP' state.\n{out}"
+    assert not out[0][dev_name]['rc'], err_msg
+
+    # 3.Configure IP addrs on 4 dut ports and connect all devices
+    address_map = (
+        # swp port,    tg port,     swp ip,    tg ip,     plen               lladdr
+        (dut_ports[0], tg_ports[0], '1.1.1.1',  '1.1.1.2',  24, 'aa:bb:cc:dd:ee:11'),
+        (dut_ports[1], tg_ports[1], '11.0.0.1', '11.0.0.2', 8,  '00:AD:20:B2:A7:75'),
+        (dut_ports[2], tg_ports[2], '12.0.0.1', '12.0.0.2', 16, '00:59:CD:1E:83:1B'),
+        (dut_ports[3], tg_ports[3], '13.0.0.1', '13.0.0.2', 20, '00:76:69:89:E0:7B'),
+    )
+    out = await IpAddress.add(input_data=[{dev_name: [
+            {'dev': port, 'prefix': f'{ip}/{plen}'} for port, _, ip, _, plen, _ in address_map]}])
+    assert not out[0][dev_name]['rc'], 'Failed to add IP addr to ports'
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': tg_port, 'ip': tg_ip, 'gw': swp_ip, 'plen': plen}
+         for _, tg_port, swp_ip, tg_ip, plen, _ in address_map])
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+
+    # 4.Add static arp entries to last 3 ports (all rx ports)
+    out = await IpNeighbor.add(input_data=[{dev_name: [
+        {'dev': port, 'address': nei_ip, 'lladdr': lladdr}
+        for port, _, _, nei_ip, _, lladdr in address_map[1:]
+    ]}])
+    assert not out[0][dev_name]['rc'], 'Failed to add static arp entries'
+
+    # 5.Configure Ecmp route to 100.0.0.0/8 with rx ports as nexthops
+    out = await IpRoute.add(input_data=[{dev_name: [
+        {'dst': '100.0.0.0/8', 'nexthop': [
+            {'via': tg_ip, 'weight': 1} for _, _, _, tg_ip, _, _ in address_map[1:]]}
+    ]}])
+    assert not out[0][dev_name]['rc'], 'Failed to add nexthop'
+
+    # 6.Setup 20 streams with identical l2/l3 info but random tcp dst/src ports value to 100.0.0.0/8 network
+    swp_info = {}
+    await tgen_utils_get_swp_info(dent_dev, dut_ports[0], swp_info)
+    stream = {f'stream_random_ports_{i}': {
+        'type': 'raw',
+        'protocol': 'ip',
+        'ip_source': dev_groups[tg_ports[0]][0]['name'],
+        'ip_destination': dev_groups[tg_ports[1]][0]['name'],  # We dont care about ip_dst as we will use port stats
+        'srcMac': random_mac(),
+        'dstMac': swp_info['mac'],
+        'srcIp': '1.1.1.20',
+        'dstIp': '100.0.0.1',
+        'ipproto': 'tcp',
+        'dstPort': randint(4000, 4500),
+        'srcPort': randint(5000, 5500),
+        'frameSize': 200,
+        'transmissionControlType': 'fixedPktCount',
+        'frameCount': 1000,
+        'rate': 1000} for i in range(20)
+    }
+    await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=stream)
+
+    # 7.Transmit all streams and wait streams to finish
+    await tgen_utils_clear_traffic_stats(tgen_dev)
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(60)
+
+    # 8.Verify traffic distributed through all expected nexthops
+    # 9.Disable net.ipv4.fib_multipath_hash_policy on teardown with fixture
+    stats = await tgen_utils_get_traffic_stats(tgen_dev)
+    await verify_ecmp_distribution(stats, tg_ports[0], tg_ports[1:])
+
+
+@pytest.mark.parametrize('tc_scenario', ['basic', 'nexthop_down', 'dynamic'])
+async def test_ecmp_traffic_distribution(testbed, tc_scenario):
+    """
+    Test Name: test_ecmp_traffic_distribution
+    Test Suite: suite_functional_ecmp
+    Test Overview: Test Ecmp traffic distribution between nexthops with next scenarios basic/nexthop_down/dynamic_arps
+    Test Procedure:
+    1. Configure 4 ports up
+    2. Configure IP addrs on 4 dut ports and connect all devices
+    3. Add static arp entries to last 3 ports (all rx ports) in case basic/nexthop_down scenario
+       In dynamic scenario arps will be generated dynamically by Ixia
+    4. Configure Ecmp route to 100.0.0.0/8 with rx ports as nexthops
+    5. Setup ipv4 stream with incremented ip_dst addresses that would distribute through all nexthops
+    6. In case of nexthop_down scenario, simulate nexthop down by setting first rx_port to down state
+    7. Transmit added stream for 15 sec
+    8. Verify traffic distributed through all expected nexthops
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    dent_dev = dent_devices[0]
+
+    # 1.Configure 4 ports up
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': port, 'operstate': 'up'} for port in dut_ports]}])
+    err_msg = f"Verify that ports set to 'UP' state.\n{out}"
+    assert not out[0][dev_name]['rc'], err_msg
+
+    # 2.Configure IP addrs on 4 dut ports and connect all devices
+    address_map = (
+        # swp port,    tg port,     swp ip,    tg ip,     plen               lladdr
+        (dut_ports[0], tg_ports[0], '1.1.1.1',  '1.1.1.2',  24, 'aa:bb:cc:dd:ee:11'),
+        (dut_ports[1], tg_ports[1], '11.0.0.1', '11.0.0.2', 8,  '00:AD:20:B2:A7:75'),
+        (dut_ports[2], tg_ports[2], '12.0.0.1', '12.0.0.2', 16, '00:59:CD:1E:83:1B'),
+        (dut_ports[3], tg_ports[3], '13.0.0.1', '13.0.0.2', 20, '00:76:69:89:E0:7B'),
+    )
+
+    out = await IpAddress.add(input_data=[{dev_name: [
+            {'dev': port, 'prefix': f'{ip}/{plen}'} for port, _, ip, _, plen, _ in address_map]}])
+    assert not out[0][dev_name]['rc'], 'Failed to add IP addr to ports'
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': tg_port, 'ip': tg_ip, 'gw': swp_ip, 'plen': plen}
+         for _, tg_port, swp_ip, tg_ip, plen, _ in address_map])
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+
+    # 3.Add static arp entries to last 3 ports (all rx ports) in case basic/nexthop_down scenario
+    # In dynamic scenario arps will be generated dynamically by Ixia
+    if tc_scenario != 'dynamic':
+        out = await IpNeighbor.add(input_data=[{dev_name: [
+            {'dev': port, 'address': nei_ip, 'lladdr': lladdr}
+            for port, _, _, nei_ip, _, lladdr in address_map[1:]
+        ]}])
+        assert not out[0][dev_name]['rc'], 'Failed to add static arp entries'
+
+    # 4.Configure Ecmp route to 100.0.0.0/8 with rx ports as nexthops
+    out = await IpRoute.add(input_data=[{dev_name: [
+        {'dst': '100.0.0.0/8', 'nexthop': [
+            {'via': tg_ip, 'weight': 1} for _, _, _, tg_ip, _, _ in address_map[1:]]}
+    ]}])
+    assert not out[0][dev_name]['rc'], 'Failed to add nexthop'
+
+    # 5.Setup ipv4 stream with incremented ip_dst addresses that would distribute through all nexthops
+    swp_info = {}
+    await tgen_utils_get_swp_info(dent_dev, dut_ports[0], swp_info)
+    stream = {'increment_ip_dst_': {
+        'type': 'raw',
+        'protocol': 'ip',
+        'ip_source': dev_groups[tg_ports[0]][0]['name'],
+        'ip_destination': dev_groups[tg_ports[1]][0]['name'],  # We dont care about ip_dst as we will use port stats
+        'srcMac': random_mac(),
+        'dstMac': swp_info['mac'],
+        'srcIp': f'1.1.1.{randint(3, 100)}',
+        'dstIp': {'type': 'increment',
+                  'start': '100.0.0.1',
+                  'step':  '0.0.0.1',
+                  'count': 30},
+        'frameSize': 200,
+        'rate': 100,
+        'frame_rate_type': 'line_rate',
+        }
+    }
+    await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=stream)
+
+    # 6.In case of nexthop_down scenario, simulate nexthop down by setting first rx_port to down state
+    if tc_scenario == 'nexthop_down':
+        out = await IpLink.set(
+            input_data=[{dev_name: [
+                {'device': dut_ports[1], 'operstate': 'down'}]}])
+        err_msg = f"Verify that ports set to 'DOWN' state.\n{out}"
+        assert not out[0][dev_name]['rc'], err_msg
+
+    # 7.Transmit added stream for 15 sec
+    await tgen_utils_clear_traffic_stats(tgen_dev)
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(15)
+    await tgen_utils_stop_traffic(tgen_dev)
+    # Wait 15 sec for stats to be updated
+    await asyncio.sleep(15)
+
+    # 8.Verify traffic distributed through all expected nexthops
+    stats = await tgen_utils_get_traffic_stats(tgen_dev)
+    if tc_scenario == 'basic' or tc_scenario == 'dynamic':
+        await verify_ecmp_distribution(stats, tg_ports[0], tg_ports[1:])
+    elif tc_scenario == 'nexthop_down':
+        await verify_ecmp_distribution(stats, tg_ports[0], tg_ports[2:])
+        for row in stats.Rows:
+            if row['Port Name'] == tg_ports[1]:
+                assert int(row[RX_STATS]) <= DEVIATION_PKTS, ERR_MSG.format(row['Port Name'], row[RX_STATS])
+
+        out = await IpLink.set(
+            input_data=[{dev_name: [
+                {'device': dut_ports[1], 'operstate': 'up'}]}])
+        err_msg = f"Verify that ports set to 'UP' state.\n{out}"
+        assert not out[0][dev_name]['rc'], err_msg
+
+
+@pytest.mark.usefixtures('cleanup_bonds')
+async def test_ecmp_distribution_lags(testbed):
+    """
+    Test Name: test_ecmp_distribution_lags
+    Test Suite: suite_functional_ecmp
+    Test Overview: Test Ecmp distribution between nexthops with ports in Lag
+    Test Procedure:
+    1. Add lag interfaces bond1 and bond2
+    2. Configure last 3 ports down in order to enslave them to bond1 and bond2
+    3. Add first rx_port to lag interface bond1 and last 2 rx_ports lag interface bond2
+    4. Configure 1st dut_port and lag interfaces bond1 and bond2 up
+    5. Configure IP addrs to 1st dut_port, bond1, bond2 interfaces
+    6. Add static arp entries to bond1 and bond2
+    7. Configure Ecmp route to 100.0.0.0/8 network with bond1 and bond2 as nexthops
+    8. Setup ipv4 stream with incremented ip_dst addresses that would distribute through all nexthops
+    9. Transmit added stream for 15 sec
+    10. Verify traffic distributed through bond1 and bond2 as expected
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    dent_dev = dent_devices[0]
+    bond1 = 'bond1'
+    bond2 = 'bond2'
+
+    # 1.Add lag interfaces bond1 and bond2
+    out = await IpLink.add(
+        input_data=[{dev_name: [
+            {'name': bond1, 'type': 'bond', 'mode': '802.3ad'},
+            {'name': bond2, 'type': 'bond', 'mode': '802.3ad'}]}])
+    err_msg = f'Verify that {bond1} and {bond2} was successfully added. \n{out}'
+    assert not out[0][dev_name]['rc'], err_msg
+
+    # 2.Configure last 3 ports down in order to enslave them to bond1 and bond2
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': port, 'operstate': 'down'} for port in dut_ports[1:]]}])
+    err_msg = f"Verify that ports {dut_ports[1:]} set to 'DOWN' state.\n{out}"
+    assert not out[0][dev_name]['rc'], err_msg
+
+    # 3.Add first rx_port to lag interface bond1 and last 2 rx_ports lag interface bond2
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dut_ports[1], 'master': bond1},
+            {'device': dut_ports[2], 'master': bond2},
+            {'device': dut_ports[3], 'master': bond2}]}])
+    err_msg = f'Verify that {dut_ports[0]} set to master .\n{out}'
+    assert not out[0][dev_name]['rc'], err_msg
+
+    # 4.Configure 1st dut_port and lag interfaces bond1 and bond2 up
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dev, 'operstate': 'up'} for dev in [dut_ports[0], bond1, bond2]]}])
+    err_msg = f"Verify that ports {[dut_ports[0], bond1, bond2]} set to 'UP' state.\n{out}"
+    assert not out[0][dev_name]['rc'], err_msg
+
+    # 5.Configure IP addrs to 1st dut_port, bond1, bond2 interfaces
+    dev_grp = (
+        {'ixp': tg_ports[0], 'ip': '1.1.1.2', 'gw': '1.1.1.1', 'plen': 24},
+        {'ixp': bond1, 'ip': '11.0.0.2', 'gw': '11.0.0.1', 'plen': 8, 'lag_members': [tg_ports[1]]},
+        {'ixp': bond2, 'ip': '12.0.0.2', 'gw': '12.0.0.1', 'plen': 16, 'lag_members': tg_ports[2:]}
+    )
+    address_map = (
+        # swp port,    tg port,     swp ip,    tg ip,     plen               lladdr
+        (dut_ports[0], tg_ports[0], '1.1.1.1',  '1.1.1.2',  24, '00:00:00:00:00:10'),
+        (bond1,        tg_ports[1], '11.0.0.1', '11.0.0.2', 8,  '00:AD:20:B2:A7:75'),
+        (bond2,        tg_ports[2:], '12.0.0.1', '12.0.0.2', 16, '00:59:CD:1E:83:1B')
+    )
+
+    out = await IpAddress.add(input_data=[{dev_name: [
+            {'dev': device, 'prefix': '{}/{}'.format(ip, plen)}
+            for device, _, ip, _, plen, _ in address_map]}])
+    assert not out[0][dev_name]['rc'], 'Failed to add IP addr to ports'
+
+    dev_groups = tgen_utils_dev_groups_from_config(dev_grp)
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+
+    # 6.Add static arp entries to bond1 and bond2
+    out = await IpNeighbor.add(input_data=[{dev_name: [
+        {'dev': device, 'address': tg_ip, 'lladdr': lladdr}
+        for device, _, _, tg_ip, _, lladdr in address_map[1:]
+    ]}])
+    assert not out[0][dev_name]['rc'], 'Failed to add static arp entries'
+
+    # 7.Configure Ecmp route to 100.0.0.0/8 network with bond1 and bond2 as nexthops
+    out = await IpRoute.add(input_data=[{dev_name: [
+        {'dst': '100.0.0.0/8', 'nexthop': [
+            {'via': tg_ip, 'weight': 1} for _, _, _, tg_ip, _, _ in address_map[1:]]}
+    ]}])
+    assert not out[0][dev_name]['rc'], 'Failed to add nexthop'
+
+    # 8.Setup ipv4 stream with incremented ip_dst addresses that would distribute through all nexthops
+    swp_info = {}
+    await tgen_utils_get_swp_info(dent_dev, dut_ports[0], swp_info)
+    stream = {'increment_ip_dst_': {
+        'type': 'raw',
+        'protocol': 'ip',
+        'ip_source': dev_groups[tg_ports[0]][0]['name'],
+        'ip_destination': dev_groups[bond1][0]['name'],  # We dont care about ip_dst as we will use port stats
+        'srcMac': random_mac(),
+        'dstMac': swp_info['mac'],
+        'srcIp': f'1.1.1.{randint(3, 100)}',
+        'dstIp': {'type': 'increment',
+                  'start': '100.0.0.1',
+                  'step':  '0.0.0.1',
+                  'count': 30},
+        'frameSize': 200,
+        'rate': 100,
+        'frame_rate_type': 'line_rate',
+        }
+    }
+    await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=stream)
+
+    # 9.Transmit added stream for 15 sec
+    await tgen_utils_clear_traffic_stats(tgen_dev)
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(15)
+    await tgen_utils_stop_traffic(tgen_dev)
+    # Wait 15 sec for stats to be updated
+    await asyncio.sleep(15)
+
+    # 10.Verify traffic distributed through bond1 and bond2 as expected
+    stats = await tgen_utils_get_traffic_stats(tgen_dev)
+    await verify_ecmp_distribution(stats, tg_ports[0], tg_ports[1:])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/conftest.py
@@ -11,32 +11,32 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
 
 @pytest_asyncio.fixture()
 async def enable_ipv4_forwarding(testbed):
-    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
-    if not tgen_dev or not dent_devices:
-        print('The testbed does not have enough dent with tgen connections')
-        return
-    dent = dent_devices[0].host_name
+    _, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 0)
+    dent_host_name = [dent.host_name for dent in dent_devices]
     ip_forward = 'net.ipv4.ip_forward'
 
     # Get ip_forward to restore it later
     out = await Sysctl.get(input_data=[{dent: [
         {'variable': ip_forward, 'options': '-n'}
-    ]}])
-    assert out[0][dent]['rc'] == 0
-    default_value = int(out[0][dent]['result'])
+    ]} for dent in dent_host_name])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res)
+    default_value = {
+        host_name: int(res[host_name]['result'])
+        for res in out for host_name in res
+    }
 
     # Enable ipv4 forwarding
     out = await Sysctl.set(input_data=[{dent: [
         {'variable': ip_forward, 'value': 1}
-    ]}])
-    assert out[0][dent]['rc'] == 0
+    ]} for dent in dent_host_name])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res)
 
     yield  # Run the test
 
     # Restore original value
     out = await Sysctl.set(input_data=[{dent: [
-        {'variable': ip_forward, 'value': default_value}
-    ]}])
+        {'variable': ip_forward, 'value': value}
+    ]} for dent, value in default_value.items()])
 
 
 @pytest_asyncio.fixture()

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/conftest.py
@@ -1,0 +1,63 @@
+import pytest_asyncio
+
+from dent_os_testbed.lib.os.service import Service
+
+
+KEEPALIVE_CONF = '/etc/keepalived/keepalived.conf'
+TEMPLATE = """
+global_defs {{
+    vrrp_garp_master_refresh 60
+}}
+
+vrrp_instance vrrp_{vr_id} {{
+    state {state}
+    interface {dev}
+    virtual_router_id {vr_id}
+    priority {prio}
+    version 3
+    use_vmac
+    vmac_xmit_base
+    virtual_ipaddress {{
+        {vr_ip}
+    }}
+    {additional_opts}
+}}
+"""
+
+
+@pytest_asyncio.fixture()
+async def configure_vrrp():
+    devs_to_clear = set()
+
+    async def apply_config(dent_dev, state, dev, prio, vr_ip, vr_id=40,
+                           additional_opts=None, apply=True, clear=True):
+        devs_to_clear.add(dent_dev)
+        dent = dent_dev.host_name
+        opts = '\n'.join(additional_opts) if type(additional_opts) is list else ''
+        append = '>' if clear else '>>'
+
+        rc, _ = await dent_dev.run_cmd(f"""
+            cat << EOF {append} {KEEPALIVE_CONF}
+                {TEMPLATE.format(state=state, dev=dev, prio=prio, vr_ip=vr_ip,
+                                 vr_id=vr_id, additional_opts=opts)}
+            \nEOF""")
+        assert rc == 0, f'Failed to add VRRP config on DUT {dent}'
+
+        if apply:
+            out = await Service.restart(input_data=[{
+                dent: [{'name': 'keepalived'}]
+            }])
+            assert out[0][dent]['rc'] == 0, f'Failed to restart keepalive service on DUT {dent}'
+
+    yield apply_config  # Run the test
+
+    for dent_dev in devs_to_clear:
+        rc, _ = await dent_dev.run_cmd(f'rm {KEEPALIVE_CONF}')
+        if rc != 0:
+            dent_dev.applog.error(f'Failed to remove {KEEPALIVE_CONF}')
+
+        out = await Service.stop(input_data=[{
+            dent_dev.host_name: [{'name': 'keepalived'}]
+        }])
+        if out[0][dent_dev.host_name]['rc'] != 0:
+            dent_dev.applog.error('Failed to stop keepalive service')

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_basic.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_basic.py
@@ -1,0 +1,189 @@
+from operator import itemgetter
+import asyncio
+import pytest
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+
+from dent_os_testbed.test.test_suite.functional.vrrp.vrrp_utils import (
+    setup_topo_for_vrrp,
+    verify_vrrp_ping,
+)
+
+
+pytestmark = [
+    pytest.mark.suite_functional_vrrp,
+    pytest.mark.usefixtures('cleanup_ip_addrs', 'enable_ipv4_forwarding', 'cleanup_bridges'),
+    pytest.mark.asyncio,
+]
+
+
+@pytest.mark.parametrize('setup', ['port', 'bridge'])
+async def test_vrrp_basic_on(testbed, setup, configure_vrrp):
+    """
+    Test Name: test_vrrp_basic_on[port|bridge]
+    Test Suite: suite_functional_vrrp
+    Test Overview:
+        Verify basic VRRP configuration
+    Test Procedure:
+    1. Configure aggregation router
+    2. Configure infra devices
+    3. Configure VRRP on infra devices
+    4. Verify infra[0] serves as master because it has a higher priority,
+       Verify infra[1] serves as backup
+    5. Make infra[0] unavailable
+    6. Verify infra[1] takes over as master
+    7. Make infra[0] active again
+    8. Expect that it takes over as the master and infra[1] reverts to backup
+
+    Setup:
+            agg
+         ___| |___
+      L0 |       | L1
+         |       |
+    infra[0]    infra[1]
+
+    Configure:
+        agg:
+            L0 and L1: master bridge
+            bridge: ip address 192.168.1.5/24
+        infra[0]:
+            L0 (port/bridge):
+                ip address 192.168.1.3/24
+                vrrp 40 ip 192.168.1.2 prio 254
+        infra[1]:
+            L1 (port/bridge):
+                ip address 192.168.1.4/24
+                vrrp 40 ip 192.168.1.2 prio 100
+    """
+    count = 10
+    vrrp_ip = '192.168.1.2'
+    vr_id = 40
+    use_bridge = setup == 'bridge'
+
+    # 1. Configure aggregation router
+    # 2. Configure infra devices
+    config = await setup_topo_for_vrrp(testbed, use_bridge)
+    infra, agg, bridge, links = itemgetter('infra', 'agg', 'bridge', 'links')(config)
+
+    # 3. Configure VRRP on infra devices
+    vrrp_ifaces = [bridge, bridge] if use_bridge else [links[0][infra[0]], links[1][infra[1]]]
+    await asyncio.gather(*[
+        configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, vr_id=vr_id, dev=port)
+        for dent, port, state, prio
+        in zip(infra, vrrp_ifaces, ['MASTER', 'BACKUP'], [254, 100])])
+    await asyncio.sleep(10)  # wait for keepalived to start
+
+    # 4. Verify infra[0] serves as master because it has a higher priority,
+    #    Verify infra[1] serves as backup
+    await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                           expected=(count*2, 0), dst=vrrp_ip, count=count)
+
+    # 5. Make infra[0] unavailable
+    out = await IpLink.set(input_data=[{
+        infra[0].host_name: [{'device': f'vrrp.{vr_id}', 'operstate': 'down'}],
+    }])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to disable vrrp'
+    await asyncio.sleep(10)  # wait for vrrp to change master
+
+    # 6. Verify infra[1] takes over as master
+    await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                           expected=(0, count*2), dst=vrrp_ip, count=count)
+
+    # 7. Make infra[0] active again
+    out = await IpLink.set(input_data=[{
+        infra[0].host_name: [{'device': f'vrrp.{vr_id}', 'operstate': 'up'}],
+    }])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to enable vrrp'
+    await asyncio.sleep(10)  # wait for vrrp to change master
+
+    # 8. Expect that it takes over as the master and infra[1] reverts to backup
+    await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                           expected=(count*2, 0), dst=vrrp_ip, count=count)
+
+
+@pytest.mark.parametrize('setup', ['port', 'bridge'])
+async def test_vrrp_basic_down_on(testbed, setup, configure_vrrp):
+    """
+    Test Name: test_vrrp_basic_down_on[port|bridge]
+    Test Suite: suite_functional_vrrp
+    Test Overview:
+        Verify VRouter doesn't reply to pings when macvlan state is down on both routers
+    Test Procedure:
+    1. Configure aggregation router
+    2. Configure infra devices
+    3. Configure VRRP on infra devices
+    4. Verify infra[0] serves as master because it has a higher priority,
+       Verify infra[1] serves as backup
+    5. Make infra[0] unavailable
+    6. Verify infra[1] takes over as master
+    7. Make infra[1] also unavailable
+    8. Expect no ICMP reply
+
+    Setup:
+            agg
+         ___| |___
+      L0 |       | L1
+         |       |
+    infra[0]    infra[1]
+
+    Configure:
+        agg:
+            L0 and L1: master bridge
+            bridge: ip address 192.168.1.5/24
+        infra[0]:
+            L0 (port/bridge):
+                ip address 192.168.1.3/24
+                vrrp 40 ip 192.168.1.2 prio 200
+        infra[1]:
+            L1 (port/bridge):
+                ip address 192.168.1.4/24
+                vrrp 40 ip 192.168.1.2 prio 100
+    """
+    count = 10
+    vrrp_ip = '192.168.1.2'
+    vr_id = 40
+    use_bridge = setup == 'bridge'
+
+    # 1. Configure aggregation router
+    # 2. Configure infra devices
+    config = await setup_topo_for_vrrp(testbed, use_bridge)
+    infra, agg, bridge, links = itemgetter('infra', 'agg', 'bridge', 'links')(config)
+
+    # 3. Configure VRRP on infra devices
+    vrrp_ifaces = [bridge, bridge] if use_bridge else [links[0][infra[0]], links[1][infra[1]]]
+    await asyncio.gather(*[
+        configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, vr_id=vr_id, dev=port)
+        for dent, port, state, prio
+        in zip(infra, vrrp_ifaces, ['MASTER', 'BACKUP'], [200, 100])])
+    await asyncio.sleep(10)  # wait for keepalived to start
+
+    # 4. Verify infra[0] serves as master because it has a higher priority,
+    #    Verify infra[1] serves as backup
+    await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                           expected=(count*2, 0), dst=vrrp_ip, count=count)
+
+    # 5. Make infra[0] unavailable
+    out = await IpLink.set(input_data=[{
+        infra[0].host_name: [{'device': f'vrrp.{vr_id}', 'operstate': 'down'}],
+    }])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to disable vrrp'
+    await asyncio.sleep(10)  # wait for vrrp to change master
+
+    # 6. Verify infra[1] takes over as master
+    await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                           expected=(0, count*2), dst=vrrp_ip, count=count)
+
+    # 7. Make infra[1] also unavailable
+    out = await IpLink.set(input_data=[{
+        infra[1].host_name: [{'device': f'vrrp.{vr_id}', 'operstate': 'down'}],
+    }])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to disable vrrp'
+    await asyncio.sleep(10)  # wait for vrrp to change master
+
+    # 8. Expect no ICMP reply
+    await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                           expected=(0, 0), dst=vrrp_ip, count=count)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_priority.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_priority.py
@@ -1,0 +1,83 @@
+from operator import itemgetter
+import asyncio
+import pytest
+
+from dent_os_testbed.test.test_suite.functional.vrrp.vrrp_utils import (
+    setup_topo_for_vrrp,
+    verify_vrrp_ping,
+)
+
+
+pytestmark = [
+    pytest.mark.suite_functional_vrrp,
+    pytest.mark.usefixtures('cleanup_ip_addrs', 'enable_ipv4_forwarding', 'cleanup_bridges'),
+    pytest.mark.asyncio,
+]
+
+
+@pytest.mark.parametrize('setup', ['port', 'bridge'])
+async def test_vrrp_priority_on(testbed, setup, configure_vrrp):
+    """
+    Test Name: test_vrrp_priority_on[port|bridge]
+    Test Suite: suite_functional_vrrp
+    Test Overview:
+        Verify that the VR configured over a port with the highest priority becomes the master.
+    Test Procedure:
+    1. Configure aggregation router
+    2. Configure infra devices
+    3. Configure VRRP on infra devices
+    4. Verify infra[0] serves as master because it has a higher priority,
+       Verify infra[1] serves as backup
+    5. Set infra[1] VRRP priority greater than the infra[0] VRRP priority
+    6. Verify infra[1] takes over as a master and infra[0] becomes a backup router
+
+    Setup:
+            agg
+         ___| |___
+      L0 |       | L1
+         |       |
+    infra[0]    infra[1]
+
+    Configure:
+        agg:
+            L0 and L1: master bridge
+            bridge: ip address 192.168.1.5/24
+        infra[0]:
+            L0 (port/bridge):
+                ip address 192.168.1.3/24
+                vrrp 40 ip 192.168.1.2 prio 200
+        infra[1]:
+            L1 (port/bridge):
+                ip address 192.168.1.4/24
+                vrrp 40 ip 192.168.1.2 prio 100(210)
+    """
+    count = 10
+    vrrp_ip = '192.168.1.2'
+    use_bridge = setup == 'bridge'
+
+    # 1. Configure aggregation router
+    # 2. Configure infra devices
+    config = await setup_topo_for_vrrp(testbed, use_bridge)
+    infra, agg, bridge, links = itemgetter('infra', 'agg', 'bridge', 'links')(config)
+
+    # 3. Configure VRRP on infra devices
+    vrrp_ifaces = [bridge, bridge] if use_bridge else [links[0][infra[0]], links[1][infra[1]]]
+    await asyncio.gather(*[
+        configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, dev=port)
+        for dent, port, state, prio
+        in zip(infra, vrrp_ifaces, ['MASTER', 'BACKUP'], [200, 100])])
+    await asyncio.sleep(10)  # wait for keepalived to start
+
+    # 4. Verify infra[0] serves as master because it has a higher priority,
+    #    Verify infra[1] serves as backup
+    await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                           expected=(count*2, 0), dst=vrrp_ip, count=count)
+
+    # 5. Set infra[1] VRRP priority greater than the infra[0] VRRP priority
+    await configure_vrrp(infra[1], state='MASTER', prio=210, vr_ip=vrrp_ip,
+                         dev=links[1][infra[1]] if setup == 'port' else bridge)
+    await asyncio.sleep(10)  # wait for keepalived to restart
+
+    # 6. Verify infra[1] takes over as a master and infra[0] becomes a backup router
+    await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                           expected=(0, count*2), dst=vrrp_ip, count=count)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/vrrp_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/vrrp_utils.py
@@ -1,0 +1,155 @@
+import asyncio
+import pytest
+
+from dent_os_testbed.Device import DeviceType
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+)
+
+from dent_os_testbed.utils.test_utils.tb_utils import (
+    tb_device_tcpdump,
+    tb_ping_device,
+)
+
+
+async def setup_topo_for_vrrp(testbed, use_bridge=False):
+    """
+    Setup:
+            agg
+         ___| |___
+      L0 |       | L1
+         |       |
+    infra[0]    infra[1]
+
+    Configure:
+        agg:
+            L0 and L1: master bridge
+            bridge: ip address 192.168.1.5/24
+        infra[0]:
+            L0 (port/bridge): ip address 192.168.1.3/24
+        infra[1]:
+            L1 (port/bridge): ip address 192.168.1.4/24
+    """
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [
+        DeviceType.AGGREGATION_ROUTER,
+        DeviceType.INFRA_SWITCH,
+    ], 0)
+    if not tgen_dev or not dent_devices or len(dent_devices) < 3:
+        pytest.skip('The testbed does not have enough devices (1 agg + 2 infra)')
+
+    infra = [dent for dent in dent_devices if dent.type == DeviceType.INFRA_SWITCH]
+    if len(infra) < 2:
+        pytest.skip('The testbed does not have enough infra devices')
+    infra = infra[:2]
+
+    agg = [dent for dent in dent_devices if dent.type == DeviceType.AGGREGATION_ROUTER]
+    if len(agg) < 1:
+        pytest.skip('The testbed does not have enough agg devices')
+    agg = agg[0]
+
+    bridge = 'br0'
+    ep_ip = '192.168.1.5/24'
+    links = [
+        # L0
+        {infra[0]: infra[0].links_dict[agg.host_name][0][0],
+         agg: infra[0].links_dict[agg.host_name][1][0]},
+        # L1
+        {infra[1]: infra[1].links_dict[agg.host_name][0][0],
+         agg: infra[1].links_dict[agg.host_name][1][0]},
+    ]
+
+    # 1. Configure aggregation router
+    out = await IpLink.add(input_data=[{agg.host_name: [
+        {'name': bridge, 'type': 'bridge'}
+    ]}])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to create bridge'
+
+    out = await IpLink.set(input_data=[{
+        agg.host_name: [
+            {'device': port, 'master': bridge, 'operstate': 'up'}
+            for port in [links[0][agg], links[1][agg]]
+        ] + [
+            {'device': bridge, 'operstate': 'up'}
+        ]
+    }])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to enslave ports'
+
+    # 2. Configure infra devices
+    if use_bridge:
+        out = await IpLink.add(input_data=[{
+            dent.host_name: [{'name': bridge, 'type': 'bridge'}]
+            for dent in infra
+        }])
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to create bridge'
+
+        out = await IpLink.set(input_data=[{
+            infra[0].host_name: [
+                {'device': links[0][infra[0]], 'operstate': 'up', 'master': bridge},
+                {'device': bridge, 'operstate': 'up'},
+            ],
+            infra[1].host_name: [
+                {'device': links[1][infra[1]], 'operstate': 'up', 'master': bridge},
+                {'device': bridge, 'operstate': 'up'},
+            ],
+        }])
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to enslave ports'
+
+        out = await IpAddress.add(input_data=[{
+            infra[0].host_name: [{'dev': bridge, 'prefix': '192.168.1.3/24'}],
+            infra[1].host_name: [{'dev': bridge, 'prefix': '192.168.1.4/24'}],
+            agg.host_name: [{'dev': bridge, 'prefix': ep_ip}],
+        }])
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to add IP addr'
+    else:  # port
+        out = await IpLink.set(input_data=[{
+            infra[0].host_name: [{'device': links[0][infra[0]], 'operstate': 'up'}],
+            infra[1].host_name: [{'device': links[1][infra[1]], 'operstate': 'up'}],
+        }])
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to set operstate to UP'
+
+        out = await IpAddress.add(input_data=[{
+            infra[0].host_name: [{'dev': links[0][infra[0]], 'prefix': '192.168.1.3/24'}],
+            infra[1].host_name: [{'dev': links[1][infra[1]], 'prefix': '192.168.1.4/24'}],
+            agg.host_name: [{'dev': bridge, 'prefix': ep_ip}],
+        }])
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to add IP addr'
+
+    return {
+        'tgen_dev': tgen_dev,
+        'infra': infra,
+        'agg': agg,
+        'bridge': bridge,
+        'ep_ip': ep_ip,
+        'links': links,
+    }
+
+
+async def verify_vrrp_ping(agg, infra, ports, expected, dst, count=10):
+    interval = 0.1
+    tcpdump = [
+        # capture 2x number of sent icmp packets (request + reply)
+        asyncio.create_task(tb_device_tcpdump(dent, port, f'-n -c {count*2} icmp',
+                                              count_only=True, timeout=interval*5 * count))
+        for dent, port in zip(infra, ports)
+    ]
+    await asyncio.sleep(1)  # give tcpdump some time to start capturing packets
+
+    rc = await tb_ping_device(agg, dst, dump=True, count=count, interval=interval)
+    if all(exp_pkt == 0 for exp_pkt in expected):
+        assert rc != 0, 'Did not expect pings to have a reply'
+    else:
+        assert rc == 0, 'Some pings did not reach their destination'
+
+    captured = await asyncio.gather(*tcpdump)
+    for dent, exp_pkt, actual_pkt in zip(infra, expected, captured):
+        assert exp_pkt == actual_pkt, f'Expected {dent} to handle {exp_pkt} icmp packets'

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/cleanup_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/cleanup_utils.py
@@ -76,7 +76,8 @@ async def cleanup_ip_addrs(dev, tgen_dev):
     """
     logger = AppLogger(DEFAULT_LOGGER)
     logger.info('Deleting IP addresses from interfaces')
-    ports = tgen_dev.links_dict[dev.host_name][1]
+    # TG-DUT links + DUT-DUT links
+    ports = tgen_dev.links_dict[dev.host_name][1] + [port for port, _ in dev.links]
 
     out = await IpAddress.flush(input_data=[{dev.host_name: [{'dev': port} for port in ports]}])
     if out[0][dev.host_name]['rc'] != 0:

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tb_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tb_utils.py
@@ -364,9 +364,10 @@ async def tb_reload_firewall(devices):
     check_asyncio_results(results, 'tb_reload_firewall')
 
 
-async def tb_ping_device(device, target, pkt_loss_treshold=50, dump=False, count=10):
+async def tb_ping_device(device, target, pkt_loss_treshold=50, dump=False, count=10, interval=None):
     pkt_stats = ''
-    cmd = f'ping -c {count} {target}'
+    inter = f'-i {interval}' if interval is not None else ''
+    cmd = f'ping -c {count} {inter} {target}'
     rc, out = await device.run_cmd(cmd, sudo=True)
     if dump:
         device.applog.info(f'Ran {cmd} on {device.host_name} with rc {rc} and out {out}')


### PR DESCRIPTION
- test_vrrp_basic_on[bridge]
- test_vrrp_basic_on[port]
- test_vrrp_priority_on[bridge]
- test_vrrp_priority_on[port]
- test_vrrp_basic_down_on[bridge]
- test_vrrp_basic_down_on[port]

Also, updated cleanup functions, since they should not care whether DUTs have any links to TG.

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>