### PR TITLE
Add lacp tests with traffics, fix cleanup and tgen utils

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/conftest.py
@@ -18,9 +18,11 @@ from dent_os_testbed.utils.test_utils.cleanup_utils import (
     cleanup_qdiscs as _cleanup_qdiscs,
     cleanup_routes as _cleanup_routes,
     cleanup_bonds as _cleanup_bonds,
+    cleanup_vrf_table_ids as _cleanup_vrf_table_ids,
     cleanup_vrfs as _cleanup_vrfs,
     cleanup_sysctl as _cleanup_sysctl,
     get_initial_routes,
+    get_initial_tables,
 )
 from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_dent_devices_with_tgen,
@@ -197,6 +199,17 @@ async def cleanup_routes(testbed):
     yield
     routes_cleanups = [_cleanup_routes(dev, initial_routes[dev.host_name]) for dev in devices]
     await asyncio.gather(*routes_cleanups)
+
+
+@pytest_asyncio.fixture
+async def cleanup_vrf_table_ids(testbed):
+    devices = await _get_dent_devs_from_testbed(testbed)
+    initial_tables = dict()
+    for dev in devices:
+        initial_tables[dev.host_name] = await get_initial_tables(dev)
+    yield
+    table_cleanups = [_cleanup_vrf_table_ids(dev, initial_tables[dev.host_name]) for dev in devices]
+    await asyncio.gather(*table_cleanups)
 
 
 @pytest_asyncio.fixture

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_distribution_over_ecmp.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_distribution_over_ecmp.py
@@ -1,0 +1,148 @@
+import asyncio
+from math import isclose
+import pytest
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+from dent_os_testbed.lib.ip.ip_route import IpRoute
+from dent_os_testbed.lib.ip.ip_neighbor import IpNeighbor
+
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
+    tgen_utils_get_swp_info,
+)
+
+pytestmark = [pytest.mark.suite_functional_lacp,
+              pytest.mark.asyncio,
+              pytest.mark.usefixtures('cleanup_tgen', 'cleanup_bonds', 'cleanup_bridges',
+                                      'enable_ipv4_forwarding')]
+
+
+async def test_lacp_ecmp_distribution_over_lag(testbed):
+    """
+    Test Name: LACP routing
+    Test Suite: suite_functional_lacp
+    Test Overview: Test ecmp distribution over lacp
+    Test Procedure:
+    1. Enable IPv4 forwarding
+    2. Create 3 bonds
+    3. Enslave
+        DUT port <==> tgen port 1 to bond 1
+        DUT port <==>  tgen port 2 to bond 2
+        DUT port <==> tgen port 3 to bond 3
+        DUT port <==>  tgen port 4 to bond 3
+    4. Set link up on all participant ports
+    5. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via 2 bonds
+    6. Setup one stream with destination IP 10.1.1.1
+    7. Transmit traffic
+    8. Verify no traffic loss; traffic distribution
+    """
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    device = dent_devices[0]
+    dent = device.host_name
+    tg_ports = tgen_dev.links_dict[dent][0]
+    ports = tgen_dev.links_dict[dent][1]
+    bonds = [f'bond_{idx}' for idx in range(1, 4)]
+    tgen_lag_1 = ('LAG_0', [tg_ports[0]])
+    tgen_lag_2 = ('LAG_1', [tg_ports[1]])
+    tgen_lag_3 = ('LAG_2', tg_ports[2:])
+    rate = 10000
+
+    # 1. Enable IPv4 forwarding
+    # 2. Create 3 bonds
+    out = await IpLink.add(input_data=[{dent: [{'device': bond, 'type': 'bond', 'mode': '802.3ad'} for bond in bonds]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add bond'
+
+    out = await IpLink.set(input_data=[{dent: [{'device': bond, 'operstate': 'up'} for bond in bonds]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting bond to state up'
+
+    # 3. Enslave DUT port <==> tgen port 1 to bond 1
+    # DUT port <==>  tgen port2 to bond 2
+    # DUT port <==> tgen port 3 to bond 2
+    # DUT port <==>  tgen port 4 to bond 3
+    out = await IpLink.set(input_data=[
+        {dent: [{'device': port, 'operstate': 'down'} for port in ports] +
+               [{'device': ports[0], 'master': bonds[0]}] +
+               [{'device': ports[1], 'master': bonds[1]}] +
+               [{'device': port, 'master': bonds[2]} for port in ports[2:]] +
+               [{'device': port, 'operstate': 'up'} for port in ports]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed changing state of the interfaces'
+
+    # 5. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via bridge
+    for id, bond in enumerate(bonds, start=1):
+        out = await IpAddress.add(input_data=[{dent: [{'dev': bond, 'prefix': f'{id}.{id}.{id}.{id}/24'}]}])
+        assert out[0][dent]['rc'] == 0, f'Failed adding IP address to {bond}'
+
+    # Add static arp entries to bond_2 and bond_3
+    out = await IpNeighbor.add(input_data=[
+        {dent: [{'dev': 'bond_2', 'address': '2.2.2.3', 'lladdr': '00:AD:20:B2:A7:75'},
+                {'dev': 'bond_3', 'address': '3.3.3.4', 'lladdr': '00:59:CD:1E:83:1B'}]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed adding ip neighbor'
+
+    out = await IpRoute.add(input_data=[{dent: [
+        {'dst': '10.1.1.0/24', 'nexthop': [{'via': '2.2.2.3', 'weight': 1}, {'via': '3.3.3.4', 'weight': 1}]}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add ip route'
+
+    # 6. Setup one stream with DIP 10.1.1.1
+    dev_groups = tgen_utils_dev_groups_from_config((
+        {'ixp': tgen_lag_1[0], 'ip': '1.1.1.2', 'gw': '1.1.1.1', 'plen': 24, 'lag_members': tgen_lag_1[1]},
+        {'ixp': tgen_lag_2[0], 'ip': '2.2.2.3', 'gw': '2.2.2.1', 'plen': 24, 'lag_members': tgen_lag_2[1]},
+        {'ixp': tgen_lag_3[0], 'ip': '3.3.3.4', 'gw': '3.3.3.1', 'plen': 24, 'lag_members': tgen_lag_3[1]}
+    ))
+
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+    swp_info = {}
+    await tgen_utils_get_swp_info(device, bonds[0], swp_info)
+    bond_1_mac = swp_info['mac']
+
+    streams = {
+        f'{tg_ports[0]} -> 10.1.1.1': {
+            'type': 'raw',
+            'ip_source': dev_groups[tgen_lag_1[0]][0]['name'],
+            'ip_destination': dev_groups[tgen_lag_3[0]][0]['name'],
+            'protocol': 'ip',
+            'dstMac': bond_1_mac,
+            'srcMac': 'aa:bb:cc:dd:ee:ff',
+            'srcIp': '1.1.1.10',
+            'dstIp': {'type': 'increment',
+                      'start': '10.1.1.1',
+                      'step':  '0.0.0.1',
+                      'count': 100},
+            'rate': rate
+        }
+    }
+    # 7. Transmit traffic
+    try:
+        await tgen_utils_setup_streams(tgen_dev, None, streams)
+    except AssertionError as e:
+        if 'LAG' in str(e):
+            pytest.skip(str(e))
+        else:
+            raise  # will re-raise the AssertionError
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(10)
+    await tgen_utils_stop_traffic(tgen_dev)
+    await asyncio.sleep(10)
+
+    # 8. Verify no traffic loss; traffic distribution
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Port Statistics')
+    tx_packets = sum([int(row['Frames Tx.']) for row in stats.Rows if row['Port Name'] in tgen_lag_1[1]])
+    for row in stats.Rows:
+        if row['Port Name'] not in tgen_lag_3[1]:
+            continue
+        err_msg = f'Expected packets  {row["Valid Frames Rx."]}, actual packets: {tx_packets / 4}'
+        assert isclose(int(row['Valid Frames Rx.']), tx_packets / 4, rel_tol=0.05), err_msg
+    total_received = sum([int(row['Valid Frames Rx.']) for row in stats.Rows])
+    assert isclose(total_received, tx_packets, rel_tol=0.05),\
+        f'Expected packets  {total_received}, actual packets: {tx_packets}'

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_negative_acl_over_lag.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_negative_acl_over_lag.py
@@ -1,0 +1,70 @@
+import pytest
+
+from dent_os_testbed.lib.tc.tc_filter import TcFilter
+from dent_os_testbed.lib.tc.tc_qdisc import TcQdisc
+from dent_os_testbed.lib.ip.ip_link import IpLink
+
+from dent_os_testbed.utils.test_utils.tgen_utils import tgen_utils_get_dent_devices_with_tgen
+
+pytestmark = [
+    pytest.mark.suite_functional_lacp,
+    pytest.mark.usefixtures('cleanup_qdiscs', 'cleanup_tgen', 'cleanup_bonds'),
+    pytest.mark.asyncio,
+]
+
+
+async def test_lacp_acl_negative(testbed):
+    """
+    Test Name: LAG with ACL
+    Test Suite: suite_functional_lacp
+    Test Overview: Verify rule is not offloaded when created on bond entity
+    Test Procedure:
+    1. Create a bond entity
+    3. Create an ingress qdisc on the LAG
+    4. Add a rule to bond entity
+    5. Verify the rule is not offloaded
+    """
+
+    # 1. Create a bond entity
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 0)
+    if not tgen_dev or not dent_devices:
+        pytest.skip(
+            'The testbed does not have enough dent with tgen connections')
+    device = dent_devices[0]
+    dent = device.host_name
+    bond = 'bond_33'
+
+    out = await IpLink.add(input_data=[{dent: [{
+        'name': bond,
+        'type': 'bond',
+        'mode': '802.3ad'
+        }]
+    }])
+    assert out[0][dent]['rc'] == 0, 'Failed creating bond entity.'
+
+    await IpLink.set(input_data=[{dent: [{'device': bond, 'operstate': 'up'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting bond to state UP.'
+
+    # 3. Create an ingress qdisc on the LAG
+
+    out = await TcQdisc.add(input_data=[{dent: [{
+        'dev': bond,
+        'direction': 'ingress'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed adding qdisc'
+    tc_rule = {
+        'dev': bond,
+        'direction': 'ingress',
+        'filtertype': {},
+        'action': 'drop'
+        }
+
+    # 4. Add a rule to bond entity
+    out = await TcFilter.add(input_data=[{dent: [tc_rule]}])
+    assert out[0][dent]['rc'] == 0, 'Fail in adding tc rule to bond'
+
+    # 5. Verify the rule is not offloaded
+    out = await TcFilter.show(input_data=[{dent: [
+        {'dev': bond, 'direction': 'ingress', 'options': '-j'}]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0, 'Fail retrieving rules'
+    not_offloaded = out[0][dent]['parsed_output'][1]['options'].get('not_in_hw')
+    assert not_offloaded, 'Verify the rule is not offloaded'

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_bridge.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_bridge.py
@@ -1,0 +1,150 @@
+import asyncio
+import pytest
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+from dent_os_testbed.lib.ip.ip_route import IpRoute
+
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_setup_streams,
+    tgen_utils_get_loss,
+    tgen_utils_start_traffic,
+    tgen_utils_get_swp_info,
+)
+pytestmark = [pytest.mark.suite_functional_lacp,
+              pytest.mark.asyncio,
+              pytest.mark.usefixtures('cleanup_tgen', 'cleanup_bonds', 'cleanup_bridges',
+                                      'enable_ipv4_forwarding')]
+
+
+async def test_lacp_routing_over_bridge(testbed):
+    """
+    Test Name: LACP routing
+    Test Suite: suite_functional_lacp
+    Test Overview: Test lacp routing over bridge
+    Test Procedure:
+    1. Enable IPv4 forwarding
+    2. Create bridge and 2 bonds
+    3. Enslave
+        DUT port <==> tgen port 1 to bond 1
+        DUT port <==>  tgen port2 to bond 2
+        DUT port <==> tgen port 3 to bond 2
+        DUT port <==>  tgen port 4 to bond 2
+    4. Enslave bond2 to bridge
+    5. Set link up on all participant ports
+    6. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via bridge
+    7. Setup one stream with DIP 10.1.1.1, and one with 2.2.2.3
+    8. Transmit traffic
+    9. Verify traffic received on bridge
+    """
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip(
+            'The testbed does not have enough dent with tgen connections')
+    device = dent_devices[0]
+    dent = device.host_name
+    tg_ports = tgen_dev.links_dict[dent][0]
+    ports = tgen_dev.links_dict[dent][1]
+    bridge = 'bridge0'
+    bond_1 = 'bond_1'
+    bond_2 = 'bond_2'
+    lag = 'LAG_1'
+    # 1. Enable IPv4 forwarding
+    # 2. Create bridge and 2 bonds
+    out = await IpLink.add(input_data=[{dent: [{'device': bridge, 'type': 'bridge'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add bridge'
+
+    out = await IpLink.set(input_data=[{dent: [{'device': bridge, 'operstate': 'up'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting bridge to state up'
+
+    out = await IpLink.add(input_data=[{dent: [
+        {'device': bond,
+         'type': 'bond',
+         'mode': '802.3ad'} for bond in [bond_1, bond_2]]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add bond'
+
+    out = await IpLink.set(input_data=[{dent: [{'device': bond, 'operstate': 'up'} for bond in [bond_1, bond_2]]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting bond to state up'
+
+    # 3. Enslave DUT port <==> tgen port 1 to bond 1
+    # DUT port <==>  tgen port2 to bond 2
+    # DUT port <==> tgen port 3 to bond 2
+    # DUT port <==>  tgen port 4 to bond 2
+    out = await IpLink.set(input_data=[
+        {dent: [{'device': port, 'operstate': 'down'} for port in ports] +
+               [{'device': ports[0], 'master': bond_1}] +
+               [{'device': port, 'master': bond_2} for port in ports[1:]] +
+               [{'device': bond_2, 'master': bridge}] +
+               [{'device': port, 'operstate': 'up'} for port in ports]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed setting enslaving and settings links up'
+
+    # 6. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via bridge
+    out = await IpAddress.add(input_data=[
+        {dent: [{'dev': bond_1, 'prefix': '1.1.1.1/24'}] +
+               [{'dev': bridge, 'prefix': '2.2.2.2/24'}]
+         }])
+    assert out[0][dent]['rc'] == 0, f'Failed adding IP address to {bond_1}'
+
+    out = await IpRoute.add(input_data=[{dent: [{'dst': '10.1.1.0/24', 'via': '2.2.2.3'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add ip route'
+
+    # 7. Setup one stream with DIP 10.1.1.1, and one with 2.2.2.3
+    dev_groups = tgen_utils_dev_groups_from_config((
+        {'ixp': tg_ports[0], 'ip': '1.1.1.2', 'gw': '1.1.1.1', 'plen': 24},
+        {'ixp': lag, 'ip': '2.2.2.3', 'gw': '2.2.2.1',
+            'plen': 24, 'lag_members': tg_ports[1:]}
+    ))
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    swp_info = {}
+    await tgen_utils_get_swp_info(device, bond_1, swp_info)
+    bridge_mac = swp_info['mac']
+
+    streams = {
+        f'{tg_ports[0]} -> 10.1.1.1/24': {
+            'type': 'raw',
+            'ip_source': dev_groups[tg_ports[0]][0]['name'],
+            'ip_destination': dev_groups[lag][0]['name'],
+            'protocol': 'ip',
+            'dstMac': bridge_mac,
+            'srcMac': 'aa:bb:cc:dd:ee:ff',
+            'dstIp': '10.1.1.1',
+            'srcIp': '1.1.1.10',
+            'frame_rate_type': 'line_rate',
+            'rate': '100'
+        },
+        f'{tg_ports[0]} -> 2.2.2.3/24 (bridge IP)': {
+            'type': 'raw',
+            'ip_source': dev_groups[tg_ports[0]][0]['name'],
+            'ip_destination': dev_groups[lag][0]['name'],
+            'protocol': 'ip',
+            'srcMac': 'aa:bb:cc:dd:ee:ff',
+            'dstMac': bridge_mac,
+            'srcIp': '1.1.1.10',
+            'dstIp': '2.2.2.3',
+            'frame_rate_type': 'line_rate',
+            'rate': '100'
+        },
+    }
+    # 8. Transmit traffic
+    try:
+        await tgen_utils_setup_streams(tgen_dev, None, streams)
+    except AssertionError as e:
+        if 'LAG' in str(e):
+            pytest.skip(str(e))
+        else:
+            raise  # will re-raise the AssertionError
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(25)
+
+    # 9. Verify traffic received on bridge
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Traffic Item Statistics')
+    for row in stats.Rows:
+        err_msg = f"Expected 0.00 loss, actual {float(row['Loss %'])}"
+        assert tgen_utils_get_loss(row) == 0.000, err_msg

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_lacp.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_lacp.py
@@ -1,0 +1,143 @@
+import asyncio
+import pytest
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+from dent_os_testbed.lib.ip.ip_route import IpRoute
+
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_setup_streams,
+    tgen_utils_get_loss,
+    tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
+    tgen_utils_get_swp_info,
+)
+pytestmark = [pytest.mark.suite_functional_lacp,
+              pytest.mark.asyncio,
+              pytest.mark.usefixtures('cleanup_tgen', 'cleanup_bonds', 'cleanup_bridges',
+                                      'enable_ipv4_forwarding')]
+
+
+async def test_lacp_routing_over_lacp(testbed):
+    """
+    Test Name: LACP routing
+    Test Suite: suite_functional_lacp
+    Test Overview: Test lacp routing over lacp
+    Test Procedure:
+    1. Enable IPv4 forwarding
+    2. Create bridge br0 and 2 bonds
+    3. Enslave DUT port <==> tgen port 1 to bond1
+        # DUT port <==>  tgen port2 to bond 2
+        # DUT port <==> tgen port 3 to bond 2
+        # DUT port <==>  tgen port 4 to bond 2
+    4. Enslave bond2 to bridge
+    5. Set link up on all participant ports
+    6. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via bond 2
+    7. Setup one stream with DIP 10.1.1.1, and one with 2.2.2.3
+    8. Transmit traffic
+    9. Verify traffic received on bridge
+    """
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip(
+            'The testbed does not have enough dent with tgen connections')
+    device = dent_devices[0]
+    dent = device.host_name
+    tg_ports = tgen_dev.links_dict[dent][0]
+    ports = tgen_dev.links_dict[dent][1]
+    bond_1 = 'bond_1'
+    bond_2 = 'bond_2'
+    lag = 'LAG_1'
+
+    # 1. Create bridge and 2 bonds
+    out = await IpLink.add(input_data=[{dent: [
+        {'device': bond,
+         'type': 'bond',
+         'mode': '802.3ad'} for bond in [bond_1, bond_2]]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add bond'
+
+    out = await IpLink.set(input_data=[{dent: [{'device': bond, 'operstate': 'up'} for bond in [bond_1, bond_2]]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting bond to state up'
+
+    # 2. Enslave DUT port <==> tgen port 1 to bond 1
+    # DUT port <==>  tgen port2 to bond 2
+    # DUT port <==> tgen port 3 to bond 2
+    # DUT port <==>  tgen port 4 to bond 2
+    out = await IpLink.set(input_data=[
+        {dent: [{'device': port, 'operstate': 'down'} for port in ports] +
+               [{'device': ports[0], 'master': bond_1}] +
+               [{'device': port, 'master': bond_2} for port in ports[1:]] +
+               [{'device': port, 'operstate': 'up'} for port in ports]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed setting links to state down'
+
+    # 6. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via bridge
+    out = await IpAddress.add(input_data=[
+        {dent: [{'dev': bond_1, 'prefix': '1.1.1.1/24'}] +
+               [{'dev': bond_2, 'prefix': '2.2.2.2/24'}]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed adding IP address'
+
+    out = await IpRoute.add(input_data=[{dent: [{'dst': '10.1.1.0/24', 'via': '2.2.2.3'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add ip route'
+
+    # 7. Setup one stream with DIP 10.1.1.1, and one with 2.2.2.3
+    dev_groups = tgen_utils_dev_groups_from_config((
+        {'ixp': tg_ports[0], 'ip': '1.1.1.2', 'gw': '1.1.1.1', 'plen': 24, },
+        {'ixp': lag, 'ip': '2.2.2.3', 'gw': '2.2.2.1',
+            'plen': 24, 'lag_members': tg_ports[1:]}
+    ))
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    swp_info = {}
+    await tgen_utils_get_swp_info(device, bond_1, swp_info)
+    bond_1_mac = swp_info['mac']
+
+    streams = {
+        f'{tg_ports[0]} -> 10.1.1.1': {
+            'type': 'raw',
+            'ip_source': dev_groups[tg_ports[0]][0]['name'],
+            'ip_destination': dev_groups[lag][0]['name'],
+            'protocol': 'ip',
+            'dstMac': bond_1_mac,
+            'srcMac': 'aa:bb:cc:dd:ee:ff',
+            'srcIp': '1.1.1.10',
+            'dstIp': '10.1.1.1',
+            'frame_rate_type': 'line_rate',
+            'rate': '100'
+        },
+        f'{tg_ports[0]} -> 2.2.2.3': {
+            'type': 'raw',
+            'ip_source': dev_groups[tg_ports[0]][0]['name'],
+            'ip_destination': dev_groups[lag][0]['name'],
+            'protocol': 'ip',
+            'srcIp': '1.1.1.10',
+            'srcMac': 'aa:bb:cc:dd:ee:ff',
+            'frame_rate_type': 'line_rate',
+            'dstMac': bond_1_mac,
+            'dstIp': '2.2.2.3',
+            'rate': '100'
+        },
+    }
+    # 8. Transmit traffic
+    try:
+        await tgen_utils_setup_streams(tgen_dev, None, streams)
+    except AssertionError as e:
+        if 'LAG' in str(e):
+            pytest.skip(str(e))
+        else:
+            raise  # will re-raise the AssertionError
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(25)
+
+    # 9. Verify no traffic loss
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Traffic Item Statistics')
+    for row in stats.Rows:
+        err_msg = f"Expected 0.00 loss, actual {float(row['Loss %'])}"
+        assert tgen_utils_get_loss(row) == 0.000, err_msg
+    await tgen_utils_stop_traffic(tgen_dev)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_vlan_device.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_vlan_device.py
@@ -1,0 +1,170 @@
+import asyncio
+import pytest
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+from dent_os_testbed.lib.ip.ip_route import IpRoute
+from dent_os_testbed.lib.bridge.bridge_vlan import BridgeVlan
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_setup_streams,
+    tgen_utils_get_loss,
+    tgen_utils_start_traffic,
+    tgen_utils_get_swp_info,
+)
+pytestmark = [pytest.mark.suite_functional_lacp,
+              pytest.mark.asyncio,
+              pytest.mark.usefixtures('cleanup_tgen', 'cleanup_bonds', 'cleanup_bridges',
+                                      'enable_ipv4_forwarding')]
+
+
+async def test_lacp_routing_over_vlan_device(testbed):
+    """
+    Test Name: LACP routing
+    Test Suite: suite_functional_lacp
+    Test Overview: Test lacp routing over vlan device
+    Test Procedure:
+    1. Enable IPv4 forwarding
+    2. Create bridge and 2 bonds
+    3. Enslave DUT port <==> tgen port 1 to bond1
+        # DUT port <==>  tgen port2 to bond 2
+        # DUT port <==> tgen port 3 to bond 2
+        # DUT port <==>  tgen port 4 to bond 2
+    4. Enslave bond2 to bridge
+    5. Set link up on all participant ports
+    6. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via vlan device
+    7. Setup one stream with DIP 10.1.1.1, and one with 2.2.2.3
+    8. Transmit traffic
+    9. Verify no traffic loss
+    """
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip(
+            'The testbed does not have enough dent with tgen connections')
+    device = dent_devices[0]
+    dent = device.host_name
+    tg_ports = tgen_dev.links_dict[dent][0]
+    ports = tgen_dev.links_dict[dent][1]
+    bridge = 'bridge_0'
+    bond_1 = 'bond_1'
+    bond_2 = 'bond_2'
+    vid = 10
+    vlan_device = f'{bridge}.{vid}'
+    lag = 'LAG_1'
+    # 1. Enable IPv4 forwarding
+    # 2. Create bridge and 2 bonds
+    out = await IpLink.add(input_data=[{dent: [{
+        'device': bridge,
+        'type': 'bridge',
+        'vlan_filtering': 1,
+        'vlan_default_pvid': vid,
+    }]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add bridge'
+
+    out = await IpLink.set(input_data=[{dent: [{'device': bridge, 'operstate': 'up'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting bridge to state up'
+
+    out = await BridgeVlan.add(input_data=[{dent: [{'device': bridge, 'vid': vid, 'self': True}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add vlan on device'
+
+    out = await IpLink.add(input_data=[{dent: [
+        {'device': bond,
+         'type': 'bond',
+         'mode': '802.3ad'} for bond in [bond_1, bond_2]]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add bond'
+
+    out = await IpLink.set(input_data=[{dent: [{'device': bond, 'operstate': 'up'} for bond in [bond_1, bond_2]]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting bond to state up'
+
+    # 3. Enslave DUT port <==> tgen port 1 to bond 1
+    # DUT port <==>  tgen port2 to bond 2
+    # DUT port <==> tgen port 3 to bond 2
+    # DUT port <==>  tgen port 4 to bond 2
+    out = await IpLink.set(input_data=[
+        {dent: [{'device': port, 'operstate': 'down'} for port in ports] +
+               [{'device': ports[0], 'master': bond_1}] +
+               [{'device': port, 'master': bond_2} for port in ports[1:]] +
+               [{'device': bond_2, 'master': bridge}] +
+               [{'device': port, 'operstate': 'up'} for port in ports]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed setting links to state down'
+
+    out = await IpLink.add(input_data=[{dent: [
+        {'link': bridge,
+         'name': vlan_device,
+         'type': 'vlan',
+         'id': vid}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add vlan device'
+
+    out = await IpLink.set(input_data=[{dent: [{'device': vlan_device, 'operstate': 'up'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting vlan device to state up'
+
+    # 6. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via vlan device
+    out = await IpAddress.add(input_data=[
+        {dent: [{'dev': bond_1, 'prefix': '1.1.1.1/24'}] +
+               [{'dev': vlan_device, 'prefix': '2.2.2.2/24'}]
+         }])
+    assert out[0][dent]['rc'] == 0, f'Failed adding IP address to {bond_1}'
+
+    out = await IpRoute.add(input_data=[{dent: [{'dst': '10.1.1.0/24', 'via': '2.2.2.3'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add ip route'
+
+    # 7. Setup one stream with DIP 10.1.1.1, and one with 2.2.2.3
+    dev_groups = tgen_utils_dev_groups_from_config((
+        {'ixp': tg_ports[0], 'ip': '1.1.1.2', 'gw': '1.1.1.1', 'plen': 24},
+        {'ixp': lag, 'ip': '2.2.2.3', 'gw': '2.2.2.1',
+            'plen': 24, 'lag_members': tg_ports[1:]}
+    ))
+
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    swp_info = {}
+    await tgen_utils_get_swp_info(device, bond_1, swp_info)
+    bridge_mac = swp_info['mac']
+
+    streams = {
+        f'{tg_ports[0]} -> 10.1.1.1/24': {
+            'type': 'raw',
+            'ip_source': dev_groups[tg_ports[0]][0]['name'],
+            'ip_destination': dev_groups[lag][0]['name'],
+            'protocol': 'ip',
+            'dstMac': bridge_mac,
+            'srcMac': 'aa:bb:cc:dd:ee:ff',
+            'dstIp': '10.1.1.1',
+            'srcIp': '1.1.1.10',
+            'frame_rate_type': 'line_rate',
+            'rate': '100'
+        },
+        f'{tg_ports[0]} -> 2.2.2.3/24 (bridge IP)': {
+            'type': 'raw',
+            'ip_source': dev_groups[tg_ports[0]][0]['name'],
+            'ip_destination': dev_groups[lag][0]['name'],
+            'protocol': 'ip',
+            'srcMac': 'aa:bb:cc:dd:ee:ff',
+            'dstMac': bridge_mac,
+            'srcIp': '1.1.1.10',
+            'dstIp': '2.2.2.3',
+            'frame_rate_type': 'line_rate',
+            'rate': '100'
+        },
+    }
+    # 8. Transmit traffic
+    try:
+        await tgen_utils_setup_streams(tgen_dev, None, streams)
+    except AssertionError as e:
+        if 'LAG' in str(e):
+            pytest.skip(str(e))
+        else:
+            raise  # will re-raise the AssertionError
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(25)
+
+    # 9. Verify no traffic loss
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Traffic Item Statistics')
+    for row in stats.Rows:
+        err_msg = f"Expected 0.00 loss, actual {float(row['Loss %'])}"
+        assert tgen_utils_get_loss(row) == 0.000, err_msg

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_vrf.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_vrf.py
@@ -1,0 +1,180 @@
+import asyncio
+from math import isclose
+import pytest
+
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+from dent_os_testbed.lib.ip.ip_route import IpRoute
+
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
+    tgen_utils_get_swp_info,
+)
+
+pytestmark = [pytest.mark.suite_functional_lacp,
+              pytest.mark.asyncio,
+              pytest.mark.usefixtures('cleanup_tgen', 'cleanup_bonds',
+                                      'cleanup_bridges', 'cleanup_vrfs', 'cleanup_routes',
+                                      'cleanup_vrf_table_ids', 'enable_ipv4_forwarding')]
+
+
+async def test_lacp_routing_over_lag_vrf(testbed):
+    """
+    Test Name: LACP routing
+    Test Suite: suite_functional_lacp
+    Test Overview: Test routing over vrf's
+    Test Procedure:
+    1. Create 3 bonds and 2 vrf tables
+    2. Enslave
+        DUT port <==> tgen port 1 to bond 1
+        DUT port <==>  tgen port 2 to bond 2
+        DUT port <==> tgen port 3 to bond 3
+        DUT port <==>  tgen port 4 to bond 3
+    3. Set link up on all participant ports
+    4. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via 2 vrf's
+    5. Setup one stream with destination IP 10.1.1.1
+    6. Transmit traffic
+    7. Verify traffic received on active bond2 port in vrf0 and not received on vrf1
+    """
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip(
+            'The testbed does not have enough dent with tgen connections')
+    device = dent_devices[0]
+    dent = device.host_name
+    tg_ports = tgen_dev.links_dict[dent][0]
+    ports = tgen_dev.links_dict[dent][1]
+    bonds = [f'bond_{idx}' for idx in range(1, 4)]
+    tgen_lag_1 = ('LAG_0', [tg_ports[0]])
+    tgen_lag_2 = ('LAG_1', [tg_ports[1]])
+    tgen_lag_3 = ('LAG_2', tg_ports[2:])
+    vrf_1 = 'vrf0'
+    vrf_2 = 'vrf1'
+    rate = 10000
+
+    # 1. Create 3 bonds
+    out = await IpLink.add(input_data=[{dent: [{'device': bond, 'type': 'bond', 'mode': '802.3ad'} for bond in bonds]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add bond'
+
+    out = await IpLink.set(input_data=[{dent: [{'device': bond, 'operstate': 'up'} for bond in bonds]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting bond to state up'
+
+    # Create 2 VRF tables
+    for vrf, table_id in zip([vrf_1, vrf_2], [10, 20]):
+        out = await IpLink.add(input_data=[{dent: [{'dev': vrf,  'type': 'vrf', 'table': table_id}]}])
+        assert out[0][dent]['rc'] == 0, 'Failed to add vrf'
+
+        out = await IpLink.set(input_data=[{dent: [{'device': vrf, 'operstate': 'up'}]}])
+        assert out[0][dent]['rc'] == 0, 'Failed setting vrf to up state'
+
+        out = await IpRoute.add(input_data=[{dent: [{'table': table_id, 'type': 'unreachable', 'table_id': 'default'}]}])
+        assert out[0][dent]['rc'] == 0, 'Failed adding route'
+
+    # 2. Enslave DUT port <==> tgen port 1 to bond 1
+    # DUT port <==>  tgen port2 to bond 2
+    # DUT port <==> tgen port 3 to bond 2
+    # DUT port <==>  tgen port 4 to bond 3
+    out = await IpLink.set(input_data=[
+        {dent: [{'device': port, 'operstate': 'down'} for port in ports] +
+               [{'device': ports[0], 'master': bonds[0]}] +
+               [{'device': ports[1], 'master': bonds[1]}] +
+               [{'device': port, 'master': bonds[2]} for port in ports[2:]]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed setting master to state down'
+
+    # 3. Set link up on all participant ports
+    out = await IpLink.set(input_data=[{dent: [{'device': port, 'operstate': 'up'} for port in ports]}])
+    assert out[0][dent]['rc'] == 0, f'Failed setting {ports[0]} to state up'
+
+    #  Enslave bond1 and bond2 to vrf1 and bond3 to vrf2
+    out = await IpLink.set(input_data=[
+        {dent: [{'device': bonds[0], 'master':vrf_1}] +
+               [{'device': bonds[1], 'master': vrf_1}] +
+               [{'device': bonds[2], 'master': vrf_2}]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed enslaving bonds to vrf'
+
+    # 4. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via bridge
+    out = await IpAddress.add(input_data=[
+        {dent: [{'dev': bonds[0], 'prefix': '1.1.1.1/24'}] +
+               [{'dev': bonds[1], 'prefix': '2.2.2.1/24'}] +
+               [{'dev': bonds[2], 'prefix': '2.2.2.1/24'}]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed adding IP address'
+
+    out = await IpRoute.add(input_data=[
+        {dent: [{'vrf': vrf_1, 'dst': '10.1.1.0/24', 'via': '2.2.2.3'}] +
+               [{'vrf': vrf_2, 'dst': '10.1.1.0/24', 'via': '2.2.2.3'}]
+         }])
+
+    assert out[0][dent]['rc'] == 0, 'Failed to add ip route'
+
+    # 5. Setup one stream with DIP 10.1.1.1, and one with 2.2.2.3
+    dev_groups = tgen_utils_dev_groups_from_config((
+        {'ixp': tgen_lag_1[0], 'ip': '1.1.1.2', 'gw': '1.1.1.1',
+            'plen': 24, 'lag_members': tgen_lag_1[1]},
+        {'ixp': tgen_lag_2[0], 'ip': '2.2.2.3', 'gw': '2.2.2.1',
+            'plen': 24, 'lag_members': tgen_lag_2[1]},
+        {'ixp': tgen_lag_3[0], 'ip': '3.3.3.4', 'gw': '3.3.3.1',
+            'plen': 24, 'lag_members': tgen_lag_3[1]}
+    ))
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+    swp_info = {}
+    await tgen_utils_get_swp_info(device, bonds[0], swp_info)
+    bond_1_mac = swp_info['mac']
+
+    streams = {
+        f'{tgen_lag_1[0]} -> {[tgen_lag_2[0], tgen_lag_3[0]]}': {
+            'type': 'raw',
+            'ip_source': dev_groups[tgen_lag_1[0]][0]['name'],
+            'ip_destination': [dev_groups[tgen_lag_3[0]][0]['name'], dev_groups[tgen_lag_2[0]][0]['name']],
+            'protocol': 'ip',
+            'dstMac': bond_1_mac,
+            'srcMac': 'aa:bb:cc:dd:ee:ff',
+            'srcIp': '1.1.1.10',
+            'dstIp': {'type': 'increment',
+                      'start': '10.1.1.1',
+                      'step':  '0.0.0.1',
+                      'count': 100},
+            'rate': rate
+        }
+    }
+    # 6. Transmit traffic
+    try:
+        await tgen_utils_setup_streams(tgen_dev, None, streams)
+    except AssertionError as e:
+        if 'LAG' in str(e):
+            pytest.skip(str(e))
+        else:
+            raise  # will re-raise the AssertionError
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(10)
+    await tgen_utils_stop_traffic(tgen_dev)
+    await asyncio.sleep(25)
+
+    # 7. Verify traffic received on active bond2 port in vrf0 and not received on vrf1
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Port Statistics')
+    tx_packets = sum([int(row['Frames Tx.'])
+                     for row in stats.Rows if row['Port Name'] in tgen_lag_1[1]])
+    total_received_bond_2 = sum([int(row['Valid Frames Rx.'])
+                                for row in stats.Rows if row['Port Name'] in tgen_lag_2[1]])
+    err_msg = f'Expected packets  {tx_packets}, actual packets: {total_received_bond_2}'
+    assert isclose(total_received_bond_2, tx_packets /
+                   len(tgen_lag_2[1]), rel_tol=0.05), err_msg
+
+    total_received_bond_3 = sum([int(row['Valid Frames Rx.'])
+                                for row in stats.Rows if row['Port Name'] in tgen_lag_3[1]])
+    err_msg = f'Expected packets  {0.0}, actual packets: {total_received_bond_3}'
+    assert total_received_bond_3 <= 50, err_msg
+
+    total_received = sum([int(row['Valid Frames Rx.']) for row in stats.Rows])
+    assert isclose(total_received, tx_packets, rel_tol=0.05),\
+        f'Expected packets  {total_received}, actual packets: {tx_packets}'

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_vrf_and_vlan_device.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_vrf_and_vlan_device.py
@@ -1,0 +1,209 @@
+import asyncio
+from math import isclose
+import pytest
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+from dent_os_testbed.lib.ip.ip_route import IpRoute
+from dent_os_testbed.lib.bridge.bridge_vlan import BridgeVlan
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
+    tgen_utils_get_swp_info,
+)
+
+pytestmark = [pytest.mark.suite_functional_lacp,
+              pytest.mark.asyncio,
+              pytest.mark.usefixtures('cleanup_vrfs', 'cleanup_tgen', 'cleanup_bonds',
+                                      'cleanup_bridges', 'cleanup_vrf_table_ids',
+                                      'cleanup_routes', 'enable_ipv4_forwarding')]
+
+
+async def test_lacp_routing_over_lag_vrf_vlan_device(testbed):
+    """
+    Test Name: LACP routing
+    Test Suite: suite_functional_lacp
+    Test Overview: Test routing over vrf's
+    Test Procedure:
+    1. Create 3 bonds and 2 vrf tables
+    2. Enslave
+        DUT port <==> tgen port 1 to bond 1
+        DUT port <==>  tgen port 2 to bond 2
+        DUT port <==> tgen port 3 to bond 3
+        DUT port <==>  tgen port 4 to bond 3
+    3. Set link up on all participant ports
+    4. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via 2 vrf's
+    5. Setup one stream with destination IP 10.1.1.1
+    6. Transmit traffic
+    7. Verify traffic received on active bond2 port in vrf0 and not received on vrf1
+    """
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip(
+            'The testbed does not have enough dent with tgen connections')
+    device = dent_devices[0]
+    dent = device.host_name
+    tg_ports = tgen_dev.links_dict[dent][0]
+    ports = tgen_dev.links_dict[dent][1]
+    bonds = [f'bond_{idx}' for idx in range(1, 4)]
+    tgen_lag_1 = ('LAG_0', [tg_ports[0]])
+    tgen_lag_2 = ('LAG_1', [tg_ports[1]])
+    tgen_lag_3 = ('LAG_2', tg_ports[2:])
+    vrf_1 = 'vrf0'
+    vrf_2 = 'vrf1'
+    vid = 10
+    bridge = 'bridge_0'
+    vlan_device = f'{bridge}.{vid}'
+    rate = 10000
+
+    # 1. Create 3 bonds and a bridge
+    out = await IpLink.add(input_data=[{dent: [{
+        'device': bridge,
+        'type': 'bridge',
+        'vlan_filtering': 1,
+        'vlan_default_pvid': 10,
+    }]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add bridge'
+
+    out = await IpLink.set(input_data=[{dent: [{'device': bridge, 'operstate': 'up'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting bridge to state up'
+
+    # Bridge to vlan id
+    out = await BridgeVlan.add(input_data=[{dent: [{'device': bridge, 'vid': vid, 'self': True}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add vlan on device'
+
+    out = await IpLink.add(input_data=[{dent: [{'device': bond, 'type': 'bond', 'mode': '802.3ad'} for bond in bonds]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add bond'
+
+    out = await IpLink.set(input_data=[{dent: [{'device': bond, 'operstate': 'up'} for bond in bonds]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting bond to state up'
+
+    # Create 2 VRF tables
+    for vrf, table_id in zip([vrf_1, vrf_2], [10, 20]):
+        out = await IpLink.add(input_data=[{dent: [{'dev': vrf, 'type': 'vrf', 'table': table_id}]}])
+        assert out[0][dent]['rc'] == 0, 'Failed to add vrf'
+
+        out = await IpLink.set(input_data=[{dent: [{'device': vrf, 'operstate': 'up'}]}])
+        assert out[0][dent]['rc'] == 0, 'Failed setting vrf to up state'
+
+        out = await IpRoute.add(
+            input_data=[{dent: [{'table': table_id, 'type': 'unreachable', 'table_id': 'default'}]}])
+        assert out[0][dent]['rc'] == 0, 'Failed adding route'
+
+    # 2. Enslave DUT port <==> tgen port 1 to bond 1
+    # DUT port <==>  tgen port2 to bond 2
+    # DUT port <==> tgen port 3 to bond 3
+    # DUT port <==>  tgen port 4 to bond 3
+    out = await IpLink.set(input_data=[
+        {dent: [{'device': port, 'operstate': 'down'} for port in ports] +
+               [{'device': ports[0], 'master': bonds[0]}] +
+               [{'device': ports[1], 'master': bonds[1]}] +
+               [{'device': port, 'master': bonds[2]} for port in ports[2:]] +
+               [{'device': bonds[2], 'master': bridge}]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed changing state of the interfaces'
+
+    # VLAN device
+    out = await IpLink.add(input_data=[{dent: [
+        {'link': bridge,
+         'name': vlan_device,
+         'type': 'vlan',
+         'id': vid}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add vlan device'
+    out = await IpLink.set(input_data=[{dent: [{'device': vlan_device, 'operstate': 'up'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting vlan device to state up'
+
+    #  Enslave bond1 and bond2 to vrf1 and bond3 to vrf2
+    out = await IpLink.set(input_data=[
+        {dent: [{'device': bonds[0], 'master': vrf_1}] +
+               [{'device': vlan_device, 'master': vrf_1}] +
+               [{'device': bonds[1], 'master': vrf_2}]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed enslaving bonds to vrfs'
+
+    # 3. Set link up on all participant ports
+    out = await IpLink.set(input_data=[{dent: [{'device': port, 'operstate': 'up'} for port in ports]}])
+    assert out[0][dent]['rc'] == 0, f'Failed setting {ports[0]} to state up'
+
+    # 4. Configure ip addresses in each LAG and configure route 10.1.1.0/24 via bridge
+    out = await IpAddress.add(input_data=[
+        {dent: [{'dev': bonds[0], 'prefix': '1.1.1.1/24'}] +
+               [{'dev': vlan_device, 'prefix': '2.2.2.1/24'}] +
+               [{'dev': bonds[1], 'prefix': '2.2.2.1/24'}]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed adding IP address to bonds'
+
+    out = await IpRoute.add(input_data=[{dent: [{'vrf': vrf_1,
+                                                 'dst': '10.1.1.0/24',
+                                                 'via': '2.2.2.3'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add ip route'
+
+    out = await IpRoute.add(input_data=[{dent: [{'vrf': vrf_2,
+                                                 'dst': '10.1.1.0/24',
+                                                 'via': '2.2.2.3'}]}])
+
+    assert out[0][dent]['rc'] == 0, 'Failed to add ip route'
+
+    # 5. Setup one stream with DIP 10.1.1.1, and one with 2.2.2.3
+    dev_groups = tgen_utils_dev_groups_from_config((
+        {'ixp': tgen_lag_1[0], 'ip': '1.1.1.2', 'gw': '1.1.1.1',
+         'plen': 24, 'lag_members': tgen_lag_1[1]},
+        {'ixp': tgen_lag_3[0], 'ip': '2.2.2.3', 'gw': '2.2.2.1',
+         'plen': 24, 'lag_members': tgen_lag_3[1]},
+        {'ixp': tgen_lag_2[0], 'ip': '3.3.3.4', 'gw': '3.3.3.1',
+         'plen': 24, 'lag_members': tgen_lag_2[1]}
+    ))
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+    swp_info = {}
+    await tgen_utils_get_swp_info(device, bonds[0], swp_info)
+    bond_1_mac = swp_info['mac']
+
+    streams = {
+        f'{tgen_lag_1[0]} -> {[tgen_lag_2[0], tgen_lag_3[0]]}': {
+            'type': 'raw',
+            'ip_source': dev_groups[tgen_lag_1[0]][0]['name'],
+            'ip_destination': [dev_groups[tgen_lag_3[0]][0]['name'], dev_groups[tgen_lag_2[0]][0]['name']],
+            'protocol': 'ip',
+            'dstMac': bond_1_mac,
+            'srcMac': 'aa:bb:cc:dd:ee:ff',
+            'srcIp': '1.1.1.10',
+            'dstIp': {'type': 'increment',
+                      'start': '10.1.1.1',
+                      'step': '0.0.0.1',
+                      'count': 100},
+            'rate': rate
+        }
+    }
+    # 6. Transmit traffic
+    try:
+        await tgen_utils_setup_streams(tgen_dev, None, streams)
+    except AssertionError as e:
+        if 'LAG' in str(e):
+            pytest.skip(str(e))
+        else:
+            raise  # will re-raise the AssertionError
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(10)
+    await tgen_utils_stop_traffic(tgen_dev)
+    await asyncio.sleep(25)
+
+    # 7. Verify traffic received on active bond2 port in vrf0 and not received on vrf1
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Port Statistics')
+    tx_packets = sum([int(row['Frames Tx.'])
+                      for row in stats.Rows if row['Port Name'] in tgen_lag_1[1]])
+    total_received_bond_3 = sum([int(row['Valid Frames Rx.'])
+                                 for row in stats.Rows if row['Port Name'] in tgen_lag_3[1]])
+    err_msg = f'Expected packets  {tx_packets}, actual packets: {total_received_bond_3}'
+    assert isclose(total_received_bond_3 /
+                   len(tgen_lag_2[1]), tx_packets / len(tgen_lag_2[1]), rel_tol=0.05), err_msg
+
+    total_received_bond_2 = sum([int(row['Valid Frames Rx.'])
+                                 for row in stats.Rows if row['Port Name'] in tgen_lag_2[1]])
+    err_msg = f'Expected packets  {0.0}, actual packets: {total_received_bond_2}'
+    assert total_received_bond_2 < 50, err_msg

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_with_all_vlan_modes.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_with_all_vlan_modes.py
@@ -1,0 +1,162 @@
+import asyncio
+from math import isclose
+import pytest
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.bridge.bridge_vlan import BridgeVlan
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
+    tgen_utils_clear_traffic_items,
+)
+
+pytestmark = [pytest.mark.suite_functional_lacp,
+              pytest.mark.asyncio,
+              pytest.mark.usefixtures('cleanup_tgen', 'cleanup_bonds', 'cleanup_bridges')]
+
+
+async def test_lacp_all_vlan_modes(testbed):
+    """
+    Test Name: LACP with VLAN
+    Test Suite: suite_functional_lacp
+    Test Overview: Test lacp with tagged/untagged traffic
+    Test Procedure:
+    1. Create 3 bonds and a bridge
+    2. Enslave
+        DUT port <==> tgen port 1 to bond 1
+        DUT port <==>  tgen port 2 to bond 2
+        DUT port <==> tgen port 3 to bond 3
+        DUT port <==>  tgen port 4 to bond 3
+    3. Set link up on all participant ports
+    4. Add bond_1 to VLAN 2 (tagged) and to 4 (pvid untagged), bond_2 to VLAN 2 (tagged), and bond_3 to 4 (pvid)
+    5. Setup one stream with uknown unicast untagged
+    6. Transmit traffic
+    7. Verify traffic received on ports within the bond_3
+    8. Setup one stream with uknown unicast, tagged VLAN 2
+    9. Verify traffic received on ports within the bond_2
+    """
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    device = dent_devices[0]
+    dent = device.host_name
+    tg_ports = tgen_dev.links_dict[dent][0]
+    ports = tgen_dev.links_dict[dent][1]
+    bonds = [f'bond_{idx}' for idx in range(1, 4)]
+    tgen_lag_1 = ('LAG_0', [tg_ports[0]])
+    tgen_lag_2 = ('LAG_1', [tg_ports[1]])
+    tgen_lag_3 = ('LAG_2', tg_ports[2:])
+    bridge = 'bridge_1'
+    rate = 10000
+
+    # 1. Create 3 bonds and a bridge
+    out = await IpLink.add(input_data=[{dent: [{'device': bridge, 'type': 'bridge',
+                                                'vlan_filtering': 1,
+                                                'vlan_default_pvid': 0}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add bridge'
+    out = await IpLink.set(input_data=[{dent: [{'device': bridge, 'operstate': 'up'}]}])
+    assert out[0][dent]['rc'] == 0, 'Failed setting bridge to up state'
+
+    out = await IpLink.add(input_data=[{dent: [{'device': bond, 'type': 'bond', 'mode': '802.3ad'} for bond in bonds]}])
+    assert out[0][dent]['rc'] == 0, 'Failed to add a bond'
+
+    # 2. Enslave DUT port <==> tgen port 1 to bond 1
+    # DUT port <==>  tgen port2 to bond 2
+    # DUT port <==> tgen port 3 to bond 2
+    # DUT port <==>  tgen port 4 to bond 3
+    out = await IpLink.set(input_data=[
+        {dent: [{'device': port, 'operstate': 'down'} for port in ports] +
+               [{'device': ports[0], 'master': bonds[0]}] +
+               [{'device': ports[1], 'master': bonds[1]}] +
+               [{'device': port, 'master': bonds[2]} for port in ports[2:]] +
+               [{'device': bond, 'master': bridge} for bond in bonds]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed setting links to state down'
+
+    # 3. Set link up on all participant ports
+    out = await IpLink.set(input_data=[
+        {dent: [{'device': port, 'operstate': 'up'} for port in ports] +
+               [{'device': bond, 'operstate': 'up'} for bond in bonds]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed setting interfaces to state up'
+
+    # 4. Add bond_1 to VLAN 2 (tagged) and to 4 (pvid untagged), bond_2 to VLAN 2 (tagged), and bond_3 to 4 (pvid)
+    out = await BridgeVlan.add(input_data=[
+        {dent: [{'device': bonds[0], 'vid': 2}] +
+               [{'device': bonds[0], 'vid': 4, 'pvid': True, 'untagged': True}] +
+               [{'device': bonds[1], 'vid': 2}] +
+               [{'device': bonds[2], 'vid': 4, 'pvid': True}]
+         }])
+    assert out[0][dent]['rc'] == 0, 'Failed adding interfaces to VLAN'
+
+    # 5. Setup one stream with uknown unicast untagged
+    dev_groups = tgen_utils_dev_groups_from_config((
+        {'ixp': tgen_lag_1[0], 'ip': '1.1.1.2', 'gw': '1.1.1.1', 'plen': 24, 'lag_members': tgen_lag_1[1]},
+        {'ixp': tgen_lag_2[0], 'ip': '2.2.2.3', 'gw': '2.2.2.1', 'plen': 24, 'lag_members': tgen_lag_2[1]},
+        {'ixp': tgen_lag_3[0], 'ip': '3.3.3.4', 'gw': '3.3.3.1', 'plen': 24, 'lag_members': tgen_lag_3[1]}
+    ))
+
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    streams = {
+        f'From {bonds[0]} -> untagged': {
+            'type': 'raw',
+            'ip_source': dev_groups[tgen_lag_1[0]][0]['name'],
+            'ip_destination': [dev_groups[tgen_lag_3[0]][0]['name'], dev_groups[tgen_lag_2[0]][0]['name']],
+            'protocol': '802.1Q',
+            'srcMac': 'aa:bb:cc:dd:ee:ff',
+            'dstMac': '22:A8:9B:BD:BE:C1',
+            'rate': rate,
+        }
+    }
+    # 6. Transmit traffic
+    try:
+        await tgen_utils_setup_streams(tgen_dev, None, streams)
+    except AssertionError as e:
+        if 'LAG' in str(e):
+            pytest.skip(str(e))
+        else:
+            raise  # will re-raise the AssertionError
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(10)
+    await tgen_utils_stop_traffic(tgen_dev)
+    await asyncio.sleep(25)
+
+    # 7. Verify traffic received on ports within the bond_3
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Port Statistics')
+    tx_packets = sum([int(row['Frames Tx.']) for row in stats.Rows if row['Port Name'] in tgen_lag_1[1]])
+    total_received = sum([int(row['Valid Frames Rx.']) for row in stats.Rows if row['Port Name'] in tgen_lag_3[1]])
+    assert isclose(total_received, tx_packets, rel_tol=0.05), f'Expected: {tx_packets}, actual: {total_received}'
+
+    await tgen_utils_clear_traffic_items(tgen_dev)
+    streams = {
+        f'From {bonds[0]} -> tagged VLAN 2': {
+            'type': 'raw',
+            'ip_source': dev_groups[tgen_lag_1[0]][0]['name'],
+            'ip_destination': [dev_groups[tgen_lag_3[0]][0]['name'], dev_groups[tgen_lag_2[0]][0]['name']],
+            'protocol': '802.1Q',
+            'srcMac': 'aa:bb:cc:dd:ee:ff',
+            'dstMac': '22:A8:9B:BD:BE:C2',
+            'rate': rate,
+            'vlanID': 2
+        }
+    }
+    # 8. Setup one stream with uknown unicast, tagged VLAN 2
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(10)
+    await tgen_utils_stop_traffic(tgen_dev)
+    await asyncio.sleep(25)
+
+    # 9. Verify traffic received on ports within the bond_2
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Port Statistics')
+    tx_packets = sum([int(row['Frames Tx.']) for row in stats.Rows if row['Port Name'] in tgen_lag_1[1]])
+    total_received = sum([int(row['Valid Frames Rx.']) for row in stats.Rows if row['Port Name'] in tgen_lag_2[1]])
+    assert isclose(total_received, tx_packets, rel_tol=0.05), f'Expected: {tx_packets}, actual: {total_received}'

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_link_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_link_impl.py
@@ -38,6 +38,8 @@ class LinuxIpLinkImpl(LinuxIpLink):
             cmd += 'numrxqueues {} '.format((params['numrxqueues']))
         if 'type' in params:
             cmd += 'type {} '.format((params['type']))
+            if params['type'] == 'vrf':
+                cmd += 'table {} '.format((params['table']))
         if 'ageing_time' in params:
             cmd += 'ageing_time {} '.format((params['ageing_time']))
         if 'vlan_filtering' in params:

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_route_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_route_impl.py
@@ -40,13 +40,15 @@ class LinuxIpRouteImpl(LinuxIpRoute):
         #            raise NameError("Cannot find prefix " + command)
         params = kwarg['params']
         cmd = 'ip {} route {} '.format(params.get('cmd_options', ''), command)
+        if 'table' in params:
+            cmd += 'table {} '.format(params.get('table'))
+        if 'vrf' in params:
+            cmd += 'vrf {} '.format(params.get('vrf'))
         if 'type' in params:
             cmd += '{} '.format(params.get('type'))
         cmd += params.get('dst', '') + ' '
         if 'tos' in params:
             cmd += 'tos {} '.format(params.get('tos'))
-        if 'table' in params:
-            cmd += 'table {} '.format(params.get('table'))
         if 'protocol' in params:
             cmd += 'proto {} '.format(params.get('protocol'))
         if 'scope' in params:
@@ -108,7 +110,8 @@ class LinuxIpRouteImpl(LinuxIpRoute):
             cmd += 'pref {} '.format(params.get('pref'))
         if 'expires' in params:
             cmd += 'expires {} '.format(params.get('expires'))
-
+        if 'table_id' in params:
+            cmd += ' {} '.format(params.get('table_id'))
         return cmd
 
     def format_get(self, command, *argv, **kwarg):


### PR DESCRIPTION
1. Add LACP tests:

- test_lacp_unsupported_modes
- test_lacp_max_lags
- test_lacp_max_ports_in_lags
- test_lacp_ecmp_distribution_over_lag
- test_lacp_acl_negative
- test_lacp_routing_over_bridge
- test_lacp_routing_over_lacp
- test_lacp_routing_over_vlan_device
- test_lacp_routing_over_lag_vrf
- test_lacp_routing_over_lag_vrf_vlan_device
- test_lacp_all_vlan_modes

2. Adds vrf table cleanup fixture