### PR TITLE
Fix Spelling Bug collateral from previous fix rename l to link

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/basic_triggers/test_module1.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/basic_triggers/test_module1.py
@@ -112,7 +112,7 @@ async def test_link_up_down(testbed):
         link_name = ''
         for link in links:
             if 'sw' in link['ifname'] and link['operstate'] == 'UP':
-                link_name = l['ifname']
+                link_name = link['ifname']
                 break
         if link_name == '':
             print('Not even single swp is UP')


### PR DESCRIPTION
Spelling Bug fixed in test: basic_triggers  -> test_module1 -> test_link_up_down
basic_triggers: test_link_up_down: Use correct variable link to assign link name