### PR TITLE
Fix `Interactive shell requested`

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/ConnectionHandlers/SSHHandler.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/ConnectionHandlers/SSHHandler.py
@@ -72,6 +72,8 @@ class SSHConnection:
             Exception: For generic failures
         """
         try:
+            if not cmd:
+                raise ValueError('Empty command is not allowed')
             self.applog.debug(f'Running {cmd}')
             await self._connect()
             self.sshlog.debug(cmd)


### PR DESCRIPTION
Passing an empty input to an API class causes the test to hang with a message `Interactive shell requested`. This state is recoverable only if the user forcefully stops the test (and as a consequence all subsequent tests). There is no timeout and the test might be hanging indefinitely.

Since we will not get any output from the connection there is no point in continuing the test execution and it is safe to raise an exception and fail the test.

This behavior is most likely to be seen in tests that fetch some data from the DUT and try to act on that data. For example the test will fetch DUT neighbors (which the DUT might or might not have) and try to remove specific entries.

```python
# normal behavior:
await IpNeighbor.show(input_data=[{dent: [{'cmd_options': '-j'}]}])  # [ ... ]

# current behavior with empty input:
await IpNeighbor.show(input_data=[{dent: []}])  # Interactive shell requested

# new behavior:
await IpNeighbor.show(input_data=[{dent: []}])  # {'rc': -1, 'result': 'Empty command is not allowed'}
```