### PR TITLE
Add VM Support for IxNetwork Client Interaction, VM Testbed Configuration

### DIFF
--- a/DentOS_Framework/DentOsTestbed/.gitignore
+++ b/DentOS_Framework/DentOsTestbed/.gitignore
@@ -15,3 +15,9 @@ __pycache__/
 
 /doc/_apidoc/
 /build
+
+logs*
+reports/
+interfaces.*
+network.html
+*.ixncfg

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/basic_infra1/testbed_vm.json
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/basic_infra1/testbed_vm.json
@@ -1,0 +1,48 @@
+{
+    "devices": [
+        {
+            "friendlyName":"DENT infrastructure 1",
+            "os":"dentos",
+            "type" : "INFRA_SWITCH",
+            "hostName": "infra1",
+            "model": "arm64-accton-as5114-48x-r0",
+            "ip": "10.36.118.45",
+            "login":{
+                "userName":"root",
+                "password":"onl"
+            },
+            "serialDev":"/dev/ttyUSB0",
+            "baudrate": 115200,
+            "mediaMode":"fiber",
+            "links" : [
+                ["swp5", "infra1:swp6"],
+                ["swp7", "infra1:swp8"],
+                ["swp9", "infra1:swp10"]
+            ]
+        },
+        {
+            "friendlyName":"Ixia Traffic Generator",
+            "os":"ixnetwork",
+            "type" : "TRAFFIC_GENERATOR",
+            "hostName": "ixia",
+            "model": "VM",
+            "ip": "10.36.118.112",
+            "login":{
+                "userName":"admin",
+                "password":"dentTestPass_121314"
+            },
+            "serialDev":"/dev/ttyUSBXX",
+            "baudrate": 115200,
+            "mediaMode":"fiber",
+            "links" : [
+                ["10.36.118.150:1:1", "infra1:swp1", "fiber"],
+                ["10.36.118.150:2:1", "infra1:swp2", "fiber"],
+                ["10.36.118.150:3:1", "infra1:swp3", "fiber"],
+                ["10.36.118.150:4:1", "infra1:swp4", "fiber"]
+            ]
+        }
+    ],
+    "operator" : "dent",
+    "topology" : "bachelor",
+    "force_discovery" : false
+}


### PR DESCRIPTION
- Workaround to skip hardware configuration of non-hardware load modules in IxNetwork Client Implementation
- Created and tested VM testbed configuration using the infra layout
- 138 Tests passing, with ongoing development to reach parity with hardware

### Test Results:
<table style="width:100%"><tr><th>Test Suite Name</th><th>Ran</th><th>Passed</th> <th>Failed</th><th>Skipped</th><th>Time</th></tr>
<tr><td>alpha_lab_testing</td><td>32</td><td>31</td> <td>1</td><td>0</td><td>2068.706</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_alpha_lab_static_routing_kernel_route_on_table</td><td>failure</td><td>ValueError: invalid literal for int() with base 10...</td></tr>
<tr><td>test_alpha_lab_bgp_routing_as_path_filtering</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_communities</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_local_pref</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_med_metric</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_allow_as_in</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_route_filtering</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_loop_detection</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_route_map</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_route_selection</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_timers</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_poe_enable_disable_ports</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_poe_enable_disable_all_ports</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_poe_enable_disable_connected_ports</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_provisioning_config_install_over_nw</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_provisioning_install_os_over_usb</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_provisioning_install_os_over_nw</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_provisioning_services_ntp</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_provisioning_services_dhcp</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_services_dhcp</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_services_lldp</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_services_ntp</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_static_routing_basic_static_route</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_static_routing_floating_vs_bgp_route</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_vlan_access_port</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_vlan_access_via_trunk_port</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_root_switch_selection</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_spanning_tree</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_spanning_tree_blocking</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_spanning_tree_failure_impact</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_trunk_port</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_vlan_segmentation</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>basic_trigger_tests</td><td>5</td><td>5</td> <td>0</td><td>0</td><td>108.253</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_reload_interface</td><td>pass</td><td></td></tr>
<tr><td>test_attr_set_unset_ip[IpLinkAttrSetAndUnset]</td><td>pass</td><td></td></tr>
<tr><td>test_delete_add_ip[IpRouteDeleteAndAdd]</td><td>pass</td><td></td></tr>
<tr><td>test_delete_add_ip[IpAddressDeleteAndAdd]</td><td>pass</td><td></td></tr>
<tr><td>test_delete_add_ip[IpLinkDeleteAndAdd]</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>bgp_tests</td><td>1</td><td>1</td> <td>0</td><td>0</td><td>0.556</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_bgp_route_and_interface_flap</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>connection</td><td>0</td><td>0</td> <td>0</td><td>0</td><td>0.665</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
</table>
</details></td></tr>
<tr><td>dentv2_testing</td><td>21</td><td>2</td> <td>19</td><td>0</td><td>6008.274</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_iptables_tc_scale</td><td>failure</td><td>AssertionError: Failed to run tc-flower-load -v  -...</td></tr>
<tr><td>test_dentv2_acl_tcp_udp_icmp_chains</td><td>failure</td><td>AssertionError: Setting tgen traffic failed.[{'ixi...</td></tr>
<tr><td>test_dentv2_acl_perf_json_fix</td><td>failure</td><td>Failed: json format error: Cannot find block "1"</td></tr>
<tr><td>test_dentv2_acl_perf_load_chains</td><td>failure</td><td>AssertionError: Load time: 175.14681196212769s, nu...</td></tr>
<tr><td>test_dentv2_acl_scale_max_rules_20B</td><td>failure</td><td>AssertionError: [{'infra1': {'command': 'tc  filte...</td></tr>
<tr><td>test_dentv2_acl_scale_max_rules_40B</td><td>failure</td><td>AssertionError: [{'infra1': {'command': 'tc  filte...</td></tr>
<tr><td>test_dentv2_acl_scale_max_rules_60B</td><td>failure</td><td>AssertionError: [{'infra1': {'command': 'tc  filte...</td></tr>
<tr><td>test_dentv2_acl_scale_max_rules_store</td><td>failure</td><td>AssertionError: Setting tgen traffic failed.[{'ixi...</td></tr>
<tr><td>test_dentv2_acl_scale_max_rules_alt_store</td><td>failure</td><td>AssertionError: [{'infra1': {'command': 'tc  filte...</td></tr>
<tr><td>test_dentv2_acl_scale_validation</td><td>failure</td><td>AssertionError: [{'infra1': {'command': 'tc  filte...</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_bonding</td><td>failure</td><td>AssertionError: Failed>Loss percent 0assert 0.0 ==...</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_bum</td><td>failure</td><td>AssertionError: Failed>Loss percent: 0assert 0.0 =...</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_config</td><td>failure</td><td>AssertionError: Failed>Loss percent: 0assert 0.0 =...</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_firewall</td><td>failure</td><td>KeyError: 'ip'</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_max_scale</td><td>failure</td><td>AssertionError</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_ifreload</td><td>failure</td><td>AssertionError: Failed>Loss percent: 0assert 0.0 =...</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_system_reload</td><td>failure</td><td>AssertionError: Failed>Loss percent: 0assert 0.0 =...</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_service_reload</td><td>failure</td><td>AssertionError: Failed>Loss percent: 0assert 0.0 =...</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_frr_reload</td><td>failure</td><td>AssertionError: Failed>Loss percent: 0assert 0.0 =...</td></tr>
<tr><td>test_dentv2_acl_perf_load_default</td><td>pass</td><td></td></tr>
<tr><td>test_dentv2_vlan_port_isolation_max_perf</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>functional</td><td>215</td><td>110</td> <td>105</td><td>27</td><td>38897.781</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_l1_port_state_status</td><td>failure</td><td>AssertionError: One of the ports, or even all of t...</td></tr>
<tr><td>test_acl_skip_sw_hw_selector[pass]</td><td>failure</td><td>AssertionError: Failed to create qdiscassert 2 == ...</td></tr>
<tr><td>test_bridging_admin_state_down_up</td><td>failure</td><td>AssertionError: Verify that traffic from 10.36.118...</td></tr>
<tr><td>test_bridging_ageing_under_continue</td><td>failure</td><td>AssertionError: Failed>Ixia should transmit traffi...</td></tr>
<tr><td>test_bridging_traffic_from_nomaster</td><td>failure</td><td>AssertionError: Verify that traffic from swp4 to s...</td></tr>
<tr><td>test_bridging_unregistered_traffic</td><td>failure</td><td>AssertionError: Verify that traffic from 10.36.118...</td></tr>
<tr><td>test_bridging_wrong_fcs</td><td>failure</td><td>AssertionError</td></tr>
<tr><td>test_bridging_jumbo_frame_size[1510]</td><td>failure</td><td>AssertionError: Verify that traffic from 10.36.118...</td></tr>
<tr><td>test_bridging_jumbo_frame_size[8998]</td><td>failure</td><td>AssertionError: Verify that traffic from 10.36.118...</td></tr>
<tr><td>test_bridging_jumbo_frame_size[9000]</td><td>failure</td><td>AssertionError: Verify that traffic from 10.36.118...</td></tr>
<tr><td>test_bridging_jumbo_frame_size[9002]</td><td>failure</td><td>AssertionError: Verify that traffic from 10.36.118...</td></tr>
<tr><td>test_bridging_learning_address</td><td>failure</td><td>AssertionError: Failed>Ixia should transmit traffi...</td></tr>
<tr><td>test_bridging_relearning_on_different_vlans</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 100.0%a...</td></tr>
<tr><td>test_bridging_packets_oversize</td><td>failure</td><td>AssertionError: Expected loss: 100%, actual: 0.0%a...</td></tr>
<tr><td>test_bridging_packets_undersize</td><td>failure</td><td>AssertionError: Expected loss: 100%, actual: 0.0%a...</td></tr>
<tr><td>test_bridging_robustness_macs</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 100.0%a...</td></tr>
<tr><td>test_bridging_static_entries</td><td>failure</td><td>AssertionError: Verify that traffic from 10.36.118...</td></tr>
<tr><td>test_bridging_unreg_traffic_ipv6</td><td>failure</td><td>AssertionError: Verify that traffic from 10.36.118...</td></tr>
<tr><td>test_devlink_interact_dyn_traps_lag</td><td>failure</td><td>AssertionError: Current rate 2894 exceeds expected...</td></tr>
<tr><td>test_devlink_interact_sct_lag</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected ra...</td></tr>
<tr><td>test_devlink_sct_basic_ports[1]</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected ra...</td></tr>
<tr><td>test_devlink_sct_basic_ports[2]</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected ra...</td></tr>
<tr><td>test_devlink_sct_basic_ports[4]</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected ra...</td></tr>
<tr><td>test_devlink_static_trap_disable</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected ra...</td></tr>
<tr><td>test_ecmp_nexthops_down[1]</td><td>failure</td><td>AssertionError: Port 10.36.118.150:4:1 received pk...</td></tr>
<tr><td>test_ecmp_nexthops_down[3]</td><td>failure</td><td>AssertionError: Failed to add static arp entriesas...</td></tr>
<tr><td>test_ecmp_hash_policy</td><td>failure</td><td>AssertionError: Port 10.36.118.150:4:1 received pk...</td></tr>
<tr><td>test_ecmp_traffic_distribution[basic]</td><td>failure</td><td>AssertionError: Failed to add static arp entriesas...</td></tr>
<tr><td>test_ecmp_traffic_distribution[nexthop_down]</td><td>failure</td><td>AssertionError: Port 10.36.118.150:4:1 received pk...</td></tr>
<tr><td>test_ecmp_traffic_distribution[dynamic]</td><td>failure</td><td>AssertionError: Port 10.36.118.150:4:1 received pk...</td></tr>
<tr><td>test_ecmp_distribution_lags</td><td>failure</td><td>AssertionError: Failed to add static arp entriesas...</td></tr>
<tr><td>test_hw_drop_l3[1]</td><td>failure</td><td>AssertionError: Current drop rate 130815 exceeds e...</td></tr>
<tr><td>test_hw_drop_l3[3]</td><td>failure</td><td>AssertionError: Failed to add static arp entriesas...</td></tr>
<tr><td>test_igmp_snooping_mixed_ver[2-2]</td><td>failure</td><td>AssertionError: Ports ['swp2', 'swp3'] absent in M...</td></tr>
<tr><td>test_igmp_snooping_mixed_ver[3-3]</td><td>failure</td><td>AssertionError: Rx_rate 0 on 10.36.118.150:4:1 exc...</td></tr>
<tr><td>test_igmp_snooping_mixed_ver[2-1]</td><td>failure</td><td>AssertionError: Ports ['swp2', 'swp3'] absent in M...</td></tr>
<tr><td>test_igmp_snooping_mixed_ver[3-1]</td><td>failure</td><td>AssertionError: Ports ['swp2', 'swp3'] absent in M...</td></tr>
<tr><td>test_igmp_snooping_mixed_ver[3-2]</td><td>failure</td><td>AssertionError: Ports ['swp2', 'swp3'] absent in M...</td></tr>
<tr><td>test_igmp_snooping_modified_query</td><td>failure</td><td>AssertionError: Ports ['swp2', 'swp3'] absent in M...</td></tr>
<tr><td>test_ipv4_addr</td><td>failure</td><td>AssertionError: Some pings did not have a replyass...</td></tr>
<tr><td>test_ipv4_dynamic_arp</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 100.0%a...</td></tr>
<tr><td>test_ipv4_replace_dyn_stat_arp</td><td>failure</td><td>AssertionError: Failed to add static arp entriesas...</td></tr>
<tr><td>test_ipv4_static_arp_with_traffic</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 100.0%a...</td></tr>
<tr><td>test_ipv4_static_route_over_static_arp</td><td>failure</td><td>AssertionError: Failed to add static arp entriesas...</td></tr>
<tr><td>test_ipv4_arp_reachable_timeout</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 100.0%a...</td></tr>
<tr><td>test_ipv4_arp_ageing</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 100.0%a...</td></tr>
<tr><td>test_ipv4_checksum</td><td>failure</td><td>AssertionError</td></tr>
<tr><td>test_ipv4_en_dis_fwd</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 0.034%a...</td></tr>
<tr><td>test_ipv4_default_gw</td><td>failure</td><td>AssertionError</td></tr>
<tr><td>test_ipv4_icmp_disabled</td><td>failure</td><td>assert False +  where False = all(<generator objec...</td></tr>
<tr><td>test_ipv4_ping_static_ip</td><td>failure</td><td>assert False +  where False = all(<generator objec...</td></tr>
<tr><td>test_ipv4_fwd_disable</td><td>failure</td><td>assert False +  where False = all(<generator objec...</td></tr>
<tr><td>test_ipv4_random_routing</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 100.0%a...</td></tr>
<tr><td>test_ipv4_nexthop_static_route</td><td>failure</td><td>AssertionError: Failed to delete arp entriesassert...</td></tr>
<tr><td>test_ipv6_move_host_on_bridge</td><td>failure</td><td>AssertionError: Expected learned mac to changeasse...</td></tr>
<tr><td>test_ipv64_nh_reconfig</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 100.0%a...</td></tr>
<tr><td>test_ipv64_nh_routes</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 100.0%a...</td></tr>
<tr><td>test_ipv6_route_lpm</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 26.041%...</td></tr>
<tr><td>test_lacp_unsupported_modes</td><td>failure</td><td>AssertionError: Bond bond_0 with unsupported mode ...</td></tr>
<tr><td>test_policer_interact_with_acl_drop</td><td>failure</td><td>AssertionError: Expected rate: 250000 got : 0.0ass...</td></tr>
<tr><td>test_policer_interaction_span</td><td>failure</td><td>AssertionError: Expected 50000000 got : 0.0assert ...</td></tr>
<tr><td>test_policer_rate_per_rule</td><td>failure</td><td>AssertionError: Expected rate for stream swp1_dst_...</td></tr>
<tr><td>test_policer_rules_priority[port]</td><td>failure</td><td>AssertionError: Expected 250000 got : 0.0assert Fa...</td></tr>
<tr><td>test_policer_same_pref_rules[port]</td><td>failure</td><td>AssertionError: Expected 250000 got : 0.0assert Fa...</td></tr>
<tr><td>test_port_isolation_basic_functionality</td><td>failure</td><td>AssertionError: Verify that traffic is forwarded/n...</td></tr>
<tr><td>test_port_isolation_enable_disable_feature_under_ws_traffic</td><td>failure</td><td>AssertionError: Verify that traffic is forwarded/n...</td></tr>
<tr><td>test_port_isolation_incremental_mac_addresses</td><td>failure</td><td>AssertionError: Verify that traffic is forwarded/n...</td></tr>
<tr><td>test_port_isolation_interaction_br_storm_control</td><td>failure</td><td>AssertionError: The rate is not limited by storm c...</td></tr>
<tr><td>test_port_isolation_interaction_mc_and_br_storm_control</td><td>failure</td><td>AssertionError: The rate is not limited by storm c...</td></tr>
<tr><td>test_port_isolation_interaction_ports_inside_lag</td><td>failure</td><td>AssertionError: Verify that traffic is forwarded/n...</td></tr>
<tr><td>test_port_isolation_interaction_span_rule</td><td>failure</td><td>AssertionError: Verify that traffic from 10.36.118...</td></tr>
<tr><td>test_port_isolation_interaction_unk_uc_storm_control</td><td>failure</td><td>AssertionError: The rate is not limited by storm c...</td></tr>
<tr><td>test_port_isolation_interaction_vlan_membership</td><td>failure</td><td>AssertionError: Verify that traffic is forwarded/n...</td></tr>
<tr><td>test_port_isolation_maximum_isolated_ports_on_bridge</td><td>failure</td><td>AssertionError: One of the ports, or even all of t...</td></tr>
<tr><td>test_port_isolation_vlan_interfaces</td><td>failure</td><td>AssertionError: Verify that traffic is forwarded/n...</td></tr>
<tr><td>test_qos_class_precedence[L2]</td><td>failure</td><td>AssertionError: Expected traffic lossassert 0.0 > ...</td></tr>
<tr><td>test_qos_class_precedence[L3]</td><td>failure</td><td>AssertionError: Expected traffic lossassert 0.0 > ...</td></tr>
<tr><td>test_qos_default_prio</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 1.987%a...</td></tr>
<tr><td>test_qos_shaper[L3]</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 4.835%a...</td></tr>
<tr><td>test_storm_control_br_and_unk_un_and_vlan_membership</td><td>failure</td><td>AssertionError: The rate is not limited by storm c...</td></tr>
<tr><td>test_storm_control_different_rates</td><td>failure</td><td>AssertionError: Failed: the rate is not limited by...</td></tr>
<tr><td>test_storm_control_interaction_policer_rules</td><td>failure</td><td>AssertionError: Failed: the rate is limited by sto...</td></tr>
<tr><td>test_storm_control_interaction_span_rule</td><td>failure</td><td>AssertionError: Failed: the rate is not limited by...</td></tr>
<tr><td>test_storm_control_mc_lag_and_vlan_membership</td><td>failure</td><td>AssertionError: The rate is not limited by storm c...</td></tr>
<tr><td>test_storm_control_packets</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected ra...</td></tr>
<tr><td>test_storm_control_rule_set_for_br_and_mc_traffic</td><td>failure</td><td>AssertionError: The rate is not limited by storm c...</td></tr>
<tr><td>test_storm_control_rule_set_for_br_and_unk_uc_traffic</td><td>failure</td><td>AssertionError: The rate is not limited by storm c...</td></tr>
<tr><td>test_stp_bpdu_filter[stp]</td><td>failure</td><td>AssertionError: Setting tgen traffic failed.[{'ixi...</td></tr>
<tr><td>test_stp_bpdu_filter[rstp]</td><td>failure</td><td>AssertionError: Setting tgen traffic failed.[{'ixi...</td></tr>
<tr><td>test_bridging_mac_table_size</td><td>failure</td><td>AssertionError: Expected count of extern_learn off...</td></tr>
<tr><td>test_vlan_all_supported_modes_broadcast</td><td>failure</td><td>AssertionError: No traffic for traffic item : traf...</td></tr>
<tr><td>test_vlan_all_supported_modes_multicast</td><td>failure</td><td>AssertionError: No traffic for traffic item : traf...</td></tr>
<tr><td>test_vlan_all_supported_modes_unicast</td><td>failure</td><td>AssertionError: No traffic for traffic item : 10.3...</td></tr>
<tr><td>test_vlan_default_configuration_with_[broadcast]</td><td>failure</td><td>AssertionError: No traffic for traffic item : Traf...</td></tr>
<tr><td>test_vlan_default_configuration_with_[multicast]</td><td>failure</td><td>AssertionError: No traffic for traffic item : Traf...</td></tr>
<tr><td>test_vlan_default_configuration_with_[unicast]</td><td>failure</td><td>AssertionError: No traffic for traffic item : 10.3...</td></tr>
<tr><td>test_vlan_default_configuration_with_[unknown_unicast]</td><td>failure</td><td>AssertionError: No traffic for traffic item : Traf...</td></tr>
<tr><td>test_vlan_changing_default_pvid</td><td>failure</td><td>AssertionError: No traffic for traffic item : Traf...</td></tr>
<tr><td>test_vlan_switching_vlan_modes_via_cli</td><td>failure</td><td>AssertionError: No traffic for traffic item : Traf...</td></tr>
<tr><td>test_vlan_tagged_ports_with_[broadcast]</td><td>failure</td><td>AssertionError: No traffic for traffic item : Traf...</td></tr>
<tr><td>test_vlan_tagged_ports_with_[multicast]</td><td>failure</td><td>AssertionError: No traffic for traffic item : Traf...</td></tr>
<tr><td>test_vlan_tagged_ports_with_[unicast]</td><td>failure</td><td>AssertionError: No traffic for traffic item : VLAN...</td></tr>
<tr><td>test_vlan_tagged_packet_size</td><td>failure</td><td>ZeroDivisionError: division by zero</td></tr>
<tr><td>test_vlan_untagged_ports_with_[broadcast]</td><td>failure</td><td>AssertionError: No traffic for traffic item : Unta...</td></tr>
<tr><td>test_vlan_untagged_ports_with_[multicast]</td><td>failure</td><td>AssertionError: No traffic for traffic item : Unta...</td></tr>
<tr><td>test_l1_forced_speed_[10000-full]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_skip_sw_hw_selector[drop]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_skip_sw_hw_selector[trap]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_rule_deletion</td><td>pass</td><td></td></tr>
<tr><td>test_acl_addition_deletion_under_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-tagged-pass]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-tagged-drop]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-tagged-trap]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-untagged-pass]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-untagged-drop]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-untagged-trap]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-tagged-pass]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-tagged-drop]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-tagged-trap]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-untagged-pass]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-untagged-drop]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-untagged-trap]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_rule_without_qdisc</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_ageing_refresh</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_bum_traffic_bridge_with_rif</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_bum_traffic_bridge_without_rif</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_bum_traffic_port_with_rif</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_bum_traffic_port_without_rif</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_backward_forwarding</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_forward_block_different_packets</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_fdb_flush_on_down</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_full_fdb_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_learning_address_rate</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_learning_illegal_address</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_remove_restore_from_vlan</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_interact_acl_with_dyn_traps</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_interact_static_traps_disabled</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_same_rule_pref[single_block]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_same_rule_pref[shared_block]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_rule_priority[single_block]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_rule_priority[shared_block]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_basic[l2]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_basic[l3]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_basic[l4]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_random</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_policer_log</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[bit]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[kbit]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[gbit]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[bps]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[kbps]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[mbps]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[gbps]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[tbps]</td><td>pass</td><td></td></tr>
<tr><td>test_hw_drop_l3_exp_counters</td><td>pass</td><td></td></tr>
<tr><td>test_igmp_snooping_diff_source_addrs</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_static_arp</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_bm_traffic_forwarding</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_class_a_dis</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_class_b_dis</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_class_c_dis</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_class_d_dis</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_class_e_dis</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_not_connected_gw</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_ping_stability</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_oversized_mtu</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_nexthop_route</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_route_between_vlan_devs</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_two_routes_to_same_net</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_basic_config</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_flags</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_secondary_addr</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_on_bridge</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_on_bridge_vlan</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_nei_ageing</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_nei_change</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_route_default_offload</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_nh_state</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_route_metrics</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_icmp</td><td>pass</td><td></td></tr>
<tr><td>test_lacp_max_lags</td><td>pass</td><td></td></tr>
<tr><td>test_lacp_max_ports_in_lags</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[port-ipv4]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[port-l2]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[port-udp]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[port-tcp]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[shared_block-ipv4]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[shared_block-l2]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[shared_block-udp]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[shared_block-tcp]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_bond_rule_not_offloaded</td><td>pass</td><td></td></tr>
<tr><td>test_policer_rate_config[IEC]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_rate_config[SI]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_rules_priority[shared_block]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_same_pref_rules[shared_block]</td><td>pass</td><td></td></tr>
<tr><td>test_qos_dscp_remarking</td><td>pass</td><td></td></tr>
<tr><td>test_qos_shaper[L2]</td><td>pass</td><td></td></tr>
<tr><td>test_qos_trust_mode[sp-L2]</td><td>pass</td><td></td></tr>
<tr><td>test_qos_trust_mode[sp-L3]</td><td>pass</td><td></td></tr>
<tr><td>test_qos_trust_mode[wrr-L2]</td><td>pass</td><td></td></tr>
<tr><td>test_qos_trust_mode[wrr-L3]</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_br_and_mc_lag_and_vlan_membership</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_broadcast_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_unk_un_lag_and_vlan_membership</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_unknown_unicast_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_unregistered_multicast_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_storm_negative_known_unicast_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_route_table_fill</td><td>pass</td><td></td></tr>
<tr><td>test_acl_table_size</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_can_set_max_vlans</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_can_not_add_interface_to_vlan_wo_bridge</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_basic_functionality</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_with_increment_macs</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_priority_tag</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_untagged_ports_with_[unicast]</td><td>pass</td><td></td></tr>
<tr><td>test_l1_autodetect[10-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autodetect[10-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autodetect[100-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autodetect[100-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autodetect[1000-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autoneg[10-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autoneg[10-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autoneg[100-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autoneg[100-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autoneg[1000-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_settings_[autodetect]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_settings_[autoneg]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_forced_speed_[10-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_forced_speed_[10-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_forced_speed_[100-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_forced_speed_[100-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_forced_speed_[1000-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_mixed_speed</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_link_up_state_software_power_cycle</td><td>skipped</td><td></td></tr>
<tr><td>test_ipv4_ping_size</td><td>skipped</td><td></td></tr>
<tr><td>test_ipv4_fragmentation</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_basic_on[port]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_basic_on[bridge]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_basic_down_on[port]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_basic_down_on[bridge]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_priority_on[port]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_priority_on[bridge]</td><td>skipped</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>l3_tests</td><td>3</td><td>2</td> <td>1</td><td>0</td><td>300.033</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_link_up_down</td><td>failure</td><td>NameError: name 'l' is not defined</td></tr>
<tr><td>test_arp_flush_w_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_route_add_del</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>platform</td><td>5</td><td>5</td> <td>0</td><td>0</td><td>1.198</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_lldp_neighor</td><td>pass</td><td></td></tr>
<tr><td>test_onlpdump</td><td>pass</td><td></td></tr>
<tr><td>test_poe_link_enable_disable_one_port</td><td>pass</td><td></td></tr>
<tr><td>test_poe_link_enable_disable_all_ports</td><td>pass</td><td></td></tr>
<tr><td>test_poe_link_enable_disable_connected_ports</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>store_bringup</td><td>0</td><td>0</td> <td>0</td><td>0</td><td>0.617</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
</table>
</details></td></tr>
<tr><td>stress_tests</td><td>3</td><td>3</td> <td>0</td><td>1</td><td>582.131</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_stress_cpu_usage</td><td>pass</td><td></td></tr>
<tr><td>test_stress_mem_usage</td><td>pass</td><td></td></tr>
<tr><td>test_stress_sock_usage</td><td>pass</td><td></td></tr>
<tr><td>test_stress_exhause_disk_space</td><td>skipped</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>system_health</td><td>1</td><td>1</td> <td>0</td><td>0</td><td>17.397</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_check_and_validate_switch_links</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>system_wide_testing</td><td>3</td><td>3</td> <td>0</td><td>0</td><td>3229.610</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_system_wide_restart_and_service_reloads</td><td>pass</td><td></td></tr>
<tr><td>test_switch_reload_all</td><td>pass</td><td></td></tr>
<tr><td>test_switch_reload_one_switch</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>tc_tests</td><td>2</td><td>0</td> <td>2</td><td>0</td><td>1332.426</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_tc_flower_persistency_w_traffic</td><td>failure</td><td>AssertionError: Failed to run tc-flower-load -v  -...</td></tr>
<tr><td>test_tc_flower_persistency_atomic_update_w_traffic</td><td>failure</td><td>AssertionError: Failed to run tc-flower-load -v  -...</td></tr>
</table>
</details></td></tr>
<tr><td>test</td><td>0</td><td>0</td> <td>0</td><td>0</td><td>0.923</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
</table>
</details></td></tr>
<tr><td>traffic_tests</td><td>3</td><td>3</td> <td>0</td><td>0</td><td>648.371</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_all_ports_tgen_w_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_basic_tgen_w_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_tgen_link_speed_change</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>TOTAL</td><td>294</td><td>138</td> <td>128</td><td>28</td><td>53196.941</td></tr>
</table>
