### PR TITLE
Fix VM Port IxNet Configuration 

### DIFF
--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -111,21 +111,19 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
 
             device.applog.info('Assigning ports')
             IxnetworkIxiaClientImpl.ixnet.AssignPorts(True)
-            portType = vports[port][0].Type
 
             lags = {}
             lag_ports = []
-            if (portType != 'ethernetvm'):
-                # init virtual lags
-                for name, group in dev_groups.items():
-                    if group[0]['type'] != 'lag':
-                        continue
-                    lag_vports = [vports[port][0].href for port in group[0]['lag_members']]
-                    lags[name] = {
-                        'vports': lag_vports,
-                        'instance': IxnetworkIxiaClientImpl.ixnet.Lag.add(Name=name, Vports=lag_vports),
-                    }
-                lag_ports = [port for lag in lags.values() for port in lag['vports']]
+            # init virtual lags
+            for name, group in dev_groups.items():
+                if group[0].get('type') != 'lag':
+                    continue
+                lag_vports = [vports[port][0].href for port in group[0]['lag_members']]
+                lags[name] = {
+                    'vports': lag_vports,
+                    'instance': IxnetworkIxiaClientImpl.ixnet.Lag.add(Name=name, Vports=lag_vports),
+                }
+            lag_ports = [port for lag in lags.values() for port in lag['vports']]
 
             self.__update_ports_mode(vports, device)
             # Add ports


### PR DESCRIPTION
# Updates
- Enable Promiscuous Mode on VM Ports
- Use consistent floating Auto-Instrumentation mode 

# Test Results:
<table style="width:100%"><tr><th>Test Suite Name</th><th>Ran</th><th>Passed</th> <th>Failed</th><th>Errors</th><th>Skipped</th><th>Time</th></tr>
<tr><td>alpha_lab_testing</td><td>32</td><td>32</td> <td>0</td><td>0</td><td>0</td><td>2300.395</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_alpha_lab_bgp_routing_as_path_filtering</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_communities</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_local_pref</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_med_metric</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_allow_as_in</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_route_filtering</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_loop_detection</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_route_map</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_route_selection</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_bgp_routing_timers</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_poe_enable_disable_ports</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_poe_enable_disable_all_ports</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_poe_enable_disable_connected_ports</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_provisioning_config_install_over_nw</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_provisioning_install_os_over_usb</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_provisioning_install_os_over_nw</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_provisioning_services_ntp</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_provisioning_services_dhcp</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_services_dhcp</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_services_lldp</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_services_ntp</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_static_routing_basic_static_route</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_static_routing_floating_vs_bgp_route</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_static_routing_kernel_route_on_table</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_vlan_access_port</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_vlan_access_via_trunk_port</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_root_switch_selection</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_spanning_tree</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_spanning_tree_blocking</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_spanning_tree_failure_impact</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_trunk_port</td><td>pass</td><td></td></tr>
<tr><td>test_alpha_lab_switching_vlan_segmentation</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>basic_trigger_tests</td><td>5</td><td>5</td> <td>0</td><td>0</td><td>0</td><td>117.174</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_reload_interface</td><td>pass</td><td></td></tr>
<tr><td>test_attr_set_unset_ip[IpLinkAttrSetAndUnset]</td><td>pass</td><td></td></tr>
<tr><td>test_delete_add_ip[IpRouteDeleteAndAdd]</td><td>pass</td><td></td></tr>
<tr><td>test_delete_add_ip[IpAddressDeleteAndAdd]</td><td>pass</td><td></td></tr>
<tr><td>test_delete_add_ip[IpLinkDeleteAndAdd]</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>bgp_tests</td><td>1</td><td>1</td> <td>0</td><td>0</td><td>0</td><td>0.747</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_bgp_route_and_interface_flap</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>clean_config</td><td>1</td><td>1</td> <td>0</td><td>0</td><td>0</td><td>9.781</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_clean_config</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>cleanup</td><td>0</td><td>0</td> <td>0</td><td>0</td><td>0</td><td>0.491</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
</table>
</details></td></tr>
<tr><td>connection</td><td>0</td><td>0</td> <td>0</td><td>0</td><td>0</td><td>0.624</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
</table>
</details></td></tr>
<tr><td>dentv2_testing</td><td>21</td><td>10</td> <td>11</td><td>0</td><td>0</td><td>8418.385</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_dentv2_acl_tcp_udp_icmp_chains</td><td>failure</td><td>AssertionError: Setting tgen traffic failed.[{'ixia': {'command': 'set_traffic', 'rc': -1, 'result':...</td></tr>
<tr><td>test_dentv2_acl_perf_load_chains</td><td>failure</td><td>AssertionError: Load time: 178.77004504203796s, num rules: 4596
assert 178.77004504203796 < 166</td></tr>
<tr><td>test_dentv2_acl_scale_max_rules_20B</td><td>failure</td><td>AssertionError: [{'infra1': {'command': 'tc  filter add dev swp1 ingress protocol 802.1q pref 1 chai...</td></tr>
<tr><td>test_dentv2_acl_scale_max_rules_40B</td><td>failure</td><td>AssertionError: [{'infra1': {'command': 'tc  filter add dev swp1 ingress protocol 802.1q pref 1 chai...</td></tr>
<tr><td>test_dentv2_acl_scale_max_rules_60B</td><td>failure</td><td>AssertionError: [{'infra1': {'command': 'tc  filter add dev swp1 ingress protocol 802.1q pref 1 chai...</td></tr>
<tr><td>test_dentv2_acl_scale_max_rules_store</td><td>failure</td><td>AssertionError: Setting tgen traffic failed.[{'ixia': {'command': 'set_traffic', 'rc': -1, 'result':...</td></tr>
<tr><td>test_dentv2_acl_scale_max_rules_alt_store</td><td>failure</td><td>AssertionError: [{'infra1': {'command': 'tc  filter add dev swp1 ingress protocol 802.1q pref 1 chai...</td></tr>
<tr><td>test_dentv2_acl_scale_validation</td><td>failure</td><td>AssertionError: [{'infra1': {'command': 'tc  filter add dev swp1 ingress protocol 802.1q pref 1 chai...</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_firewall</td><td>failure</td><td>KeyError: 'ip'</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_max_scale</td><td>failure</td><td>AssertionError</td></tr>
<tr><td>test_dentv2_vlan_port_isolation_ifreload</td><td>failure</td><td>AssertionError: Failed to perform ifreload -a [{'infra1': {'command': 'ifreload -a ', 'rc': 1, 'resu...</td></tr>
<tr><td>test_iptables_tc_scale</td><td>pass</td><td></td></tr>
<tr><td>test_dentv2_acl_perf_json_fix</td><td>pass</td><td></td></tr>
<tr><td>test_dentv2_acl_perf_load_default</td><td>pass</td><td></td></tr>
<tr><td>test_dentv2_vlan_port_isolation_bonding</td><td>pass</td><td></td></tr>
<tr><td>test_dentv2_vlan_port_isolation_bum</td><td>pass</td><td></td></tr>
<tr><td>test_dentv2_vlan_port_isolation_config</td><td>pass</td><td></td></tr>
<tr><td>test_dentv2_vlan_port_isolation_max_perf</td><td>pass</td><td></td></tr>
<tr><td>test_dentv2_vlan_port_isolation_system_reload</td><td>pass</td><td></td></tr>
<tr><td>test_dentv2_vlan_port_isolation_service_reload</td><td>pass</td><td></td></tr>
<tr><td>test_dentv2_vlan_port_isolation_frr_reload</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>functional</td><td>281</td><td>218</td> <td>61</td><td>2</td><td>40</td><td>69134.036</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_lacp_routing_over_lag_vrf</td><td>error</td><td></td></tr>
<tr><td>test_lacp_routing_over_lag_vrf_vlan_device</td><td>error</td><td></td></tr>
<tr><td>test_l1_forced_speed_[10000-full]</td><td>failure</td><td>AssertionError: No traffic for traffic item 10.36.118.150:1:1 --> 10.36.118.150:2:1: expected 0.000 ...</td></tr>
<tr><td>test_acl_skip_sw_hw_selector[pass]</td><td>failure</td><td>AssertionError: Failed to create qdisc
assert 2 == 0</td></tr>
<tr><td>test_bridging_wrong_fcs</td><td>failure</td><td>AssertionError:  Error in L2/L3 Traffic Apply</td></tr>
<tr><td>test_bridging_packets_oversize</td><td>failure</td><td>AssertionError: Verify that quantity of oversized packets is correct.assert 19522 == 19521 +  where ...</td></tr>
<tr><td>test_bridging_packets_undersize</td><td>failure</td><td>AssertionError: Expected loss: 100%, actual: 0.005%
assert 0.005 == 100</td></tr>
<tr><td>test_devlink_interact_sct_lag</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected rate 200 for cpu stat code 28</td></tr>
<tr><td>test_devlink_sct_basic_ports[1]</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected rate 200 for cpu stat code 28</td></tr>
<tr><td>test_devlink_sct_basic_ports[2]</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected rate 200 for cpu stat code 28</td></tr>
<tr><td>test_devlink_sct_basic_ports[4]</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected rate 200 for cpu stat code 28</td></tr>
<tr><td>test_devlink_static_trap_disable</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected rate 65000 for cpu stat code 28</td></tr>
<tr><td>test_ecmp_nexthops_down[3]</td><td>failure</td><td>AssertionError: Failed to add static arp entries
assert not 2</td></tr>
<tr><td>test_ecmp_traffic_distribution[basic]</td><td>failure</td><td>AssertionError: Failed to add static arp entries
assert not 2</td></tr>
<tr><td>test_ecmp_distribution_lags</td><td>failure</td><td>AssertionError: Failed to add static arp entries
assert not 2</td></tr>
<tr><td>test_hw_drop_l3[3]</td><td>failure</td><td>AssertionError: Failed to add static arp entries
assert not 2</td></tr>
<tr><td>test_hw_drop_l3_exp_counters</td><td>failure</td><td>AssertionError: Counetrs after 8097570 are not greater than counters before 8097570 for 8097570asser...</td></tr>
<tr><td>test_ifupdown2_bridge</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 100.0%
assert 100.0 == 0</td></tr>
<tr><td>test_ifupdown2_acl_random[shared_block-acl_random]</td><td>failure</td><td>AssertionError: Current rate 715168 exceeds expected rate 237774</td></tr>
<tr><td>test_igmp_snooping_mixed_ver[2-2]</td><td>failure</td><td>AssertionError: Ports ['swp2', 'swp3'] absent in Mdb [{'index': 55, 'dev': 'br0', 'port': 'br0', 'gr...</td></tr>
<tr><td>test_igmp_snooping_mixed_ver[3-3]</td><td>failure</td><td>AssertionError: No MDB router entries were added to bridge MDB table {}assert 0 +  where 0 = len({})...</td></tr>
<tr><td>test_igmp_snooping_mixed_ver[2-1]</td><td>failure</td><td>AssertionError: Ports ['swp2', 'swp3'] absent in Mdb [{'index': 57, 'dev': 'br0', 'port': 'br0', 'gr...</td></tr>
<tr><td>test_igmp_snooping_mixed_ver[3-1]</td><td>failure</td><td>AssertionError: Ports ['swp2', 'swp3'] absent in Mdb [{'index': 58, 'dev': 'br0', 'port': 'br0', 'gr...</td></tr>
<tr><td>test_igmp_snooping_mixed_ver[3-2]</td><td>failure</td><td>AssertionError: Ports ['swp2', 'swp3'] absent in Mdb [{'index': 59, 'dev': 'br0', 'port': 'br0', 'gr...</td></tr>
<tr><td>test_igmp_snooping_modified_query</td><td>failure</td><td>AssertionError: Ports ['swp2', 'swp3'] absent in Mdb [{'index': 61, 'dev': 'br0', 'port': 'br0', 'gr...</td></tr>
<tr><td>test_ipv4_replace_dyn_stat_arp</td><td>failure</td><td>AssertionError: Failed to add static arp entries
assert 2 == 0</td></tr>
<tr><td>test_ipv4_static_route_over_static_arp</td><td>failure</td><td>AssertionError: Failed to add static arp entries
assert 2 == 0</td></tr>
<tr><td>test_ipv4_checksum</td><td>failure</td><td>AssertionError:  Error in L2/L3 Traffic Apply</td></tr>
<tr><td>test_ipv4_random_routing</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 100.0%
assert 100.0 == 0</td></tr>
<tr><td>test_ipv6_move_host_on_bridge</td><td>failure</td><td>AssertionError: Expected learned mac to changeassert '00:12:01:00:00:01' not in ['00:12:01:00:00:01'...</td></tr>
<tr><td>test_lacp_ecmp_distribution_over_lag</td><td>failure</td><td>AssertionError: Expected packets  39576, actual packets: 36642.75assert False +  where False = isclo...</td></tr>
<tr><td>test_lacp_loopback_detection[rstp]</td><td>failure</td><td>AssertionError: Expected 1400 got : 342.229assert 342.229 > 1400 +  where 342.229 = float('342.229')...</td></tr>
<tr><td>test_lacp_loopback_detection[stp]</td><td>failure</td><td>AssertionError: Expected 1400 got : 325.517assert 325.517 > 1400 +  where 325.517 = float('325.517')...</td></tr>
<tr><td>test_lacp_routing_over_bridge</td><td>failure</td><td>ValueError: could not convert string to float: ''</td></tr>
<tr><td>test_lacp_routing_over_lacp</td><td>failure</td><td>ValueError: could not convert string to float: ''</td></tr>
<tr><td>test_lacp_routing_over_vlan_device</td><td>failure</td><td>ValueError: could not convert string to float: ''</td></tr>
<tr><td>test_lacp_routing_over_lag_vrf</td><td>failure</td><td>AssertionError: Failed to add vrf
assert 2 == 0</td></tr>
<tr><td>test_lacp_routing_over_lag_vrf_vlan_device</td><td>failure</td><td>AssertionError: Failed to add vrf
assert 2 == 0</td></tr>
<tr><td>test_lacp_traffic_during_topology_convergence[stp]</td><td>failure</td><td>AssertionError: Expected 1400 got : {float(row["Rx. Rate (Mbps)"])}assert False +  where False = isc...</td></tr>
<tr><td>test_lacp_traffic_during_topology_convergence[rstp]</td><td>failure</td><td>AssertionError: Expected 1400 got : {float(row["Rx. Rate (Mbps)"])}assert False +  where False = isc...</td></tr>
<tr><td>test_lldp_received[basic]</td><td>failure</td><td>AssertionError: rx_after 842 != expected amount of pkts 847
assert 842 == (841 + 6)</td></tr>
<tr><td>test_lldp_received[mandatory]</td><td>failure</td><td>AssertionError: Expected value 00:19:2f:a7:b2:8d for chassis actual value 00:00:00:00:01:00</td></tr>
<tr><td>test_lldp_received[optional]</td><td>failure</td><td>KeyError: 'S2.cisco.com'</td></tr>
<tr><td>test_lldp_received[ttl]</td><td>failure</td><td>AssertionError: Expected value 00:00:00:11:11:11 for chassis actual value 00:00:00:00:01:00</td></tr>
<tr><td>test_lldp_rx[disable]</td><td>failure</td><td>AssertionError: LLDP neighbout still exist.  [{'infra1': {'command': 'lldpcli configure ports swp1 l...</td></tr>
<tr><td>test_lldp_rx[port_down_up]</td><td>failure</td><td>AssertionError: Expected value a2:2c:38:b8:9c:a6 for chassis actual value 00:00:00:00:01:00</td></tr>
<tr><td>test_lldp_max_neighbours</td><td>failure</td><td>AssertionError: Current neighbors amount 1 is not equal to expected 32assert 1 == 32 +  where 1 = in...</td></tr>
<tr><td>test_lldp_bridge</td><td>failure</td><td>AssertionError: Expected value a2:2c:38:b8:9c:a6 for chassis actual value 00:00:00:00:01:00</td></tr>
<tr><td>test_lldp_enable_disable_ports</td><td>failure</td><td>AssertionError: Expected value 02:10:c5:aa:4e:3e for chassis actual value 00:00:00:00:01:01</td></tr>
<tr><td>test_lldp_lag</td><td>failure</td><td>AssertionError: Expected value 02:60:eb:67:4b:90 for chassis actual value 00:00:00:00:01:00</td></tr>
<tr><td>test_port_isolation_enable_disable_feature_under_ws_traffic</td><td>failure</td><td>AssertionError: Verify that traffic is forwarded/not forwarded in accordance.assert 0.015 == 0 +  wh...</td></tr>
<tr><td>test_qos_class_precedence[L2]</td><td>failure</td><td>AssertionError: Expected traffic loss
assert 0.0 > 0</td></tr>
<tr><td>test_qos_class_precedence[L3]</td><td>failure</td><td>AssertionError: Expected traffic loss
assert 0.0 > 0</td></tr>
<tr><td>test_qos_default_prio</td><td>failure</td><td>AssertionError: Expected loss: 0%, actual: 13.344%
assert 13.344 == 0</td></tr>
<tr><td>test_storm_control_different_rates</td><td>failure</td><td>AssertionError: Failed: the rate is not limited by storm control for {'stream_1_swp1->swp2': 1672, '...</td></tr>
<tr><td>test_storm_control_interaction_span_rule</td><td>failure</td><td>AssertionError: Failed: the rate is limited by storm control.assert False +  where False = <built-in...</td></tr>
<tr><td>test_storm_control_packets</td><td>failure</td><td>AssertionError: Current rate 0 exceeds expected rate 200 for trap_code lldp</td></tr>
<tr><td>test_stp_loopback_detection[stp]</td><td>failure</td><td>AssertionError: Expected 1400 got : 292.151assert 292.151 > 1400 +  where 292.151 = float('292.151')...</td></tr>
<tr><td>test_stp_loopback_detection[rstp]</td><td>failure</td><td>AssertionError: Expected 1400 got : 319.988assert 319.988 > 1400 +  where 319.988 = float('319.988')...</td></tr>
<tr><td>test_stp_bpdu_filter[stp]</td><td>failure</td><td>AssertionError: Expected rate 300000000, but actual is 144393599.628 (data traffic => 10.36.118.150:...</td></tr>
<tr><td>test_stp_traffic_during_mode_change[rstp]</td><td>failure</td><td>AssertionError: Expected 300 got : 0.0assert False +  where False = isclose(0.0, 300, rel_tol=0.05) ...</td></tr>
<tr><td>test_stp_switching_off_on[stp]</td><td>failure</td><td>AssertionError: Expected 300 got : 0.0assert False +  where False = isclose(0.0, 300, rel_tol=0.05) ...</td></tr>
<tr><td>test_bridging_mac_table_size</td><td>failure</td><td>AssertionError: Expected count of extern_learn offload entities: 4000, Actual count: 4006assert 4006...</td></tr>
<tr><td>test_l1_port_state_status</td><td>pass</td><td></td></tr>
<tr><td>test_acl_skip_sw_hw_selector[drop]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_skip_sw_hw_selector[trap]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_rule_deletion</td><td>pass</td><td></td></tr>
<tr><td>test_acl_addition_deletion_under_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-tagged-pass]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-tagged-drop]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-tagged-trap]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-untagged-pass]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-untagged-drop]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[shared_block-untagged-trap]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-tagged-pass]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-tagged-drop]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-tagged-trap]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-untagged-pass]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-untagged-drop]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_all_selectors[port-untagged-trap]</td><td>pass</td><td></td></tr>
<tr><td>test_acl_rule_without_qdisc</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_admin_state_down_up</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_ageing_refresh</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_ageing_under_continue</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_bum_traffic_bridge_with_rif</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_bum_traffic_bridge_without_rif</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_bum_traffic_port_with_rif</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_bum_traffic_port_without_rif</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_backward_forwarding</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_forward_block_different_packets</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_fdb_flush_on_down</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_traffic_from_nomaster</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_unregistered_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_full_fdb_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_jumbo_frame_size[1510]</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_jumbo_frame_size[8998]</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_jumbo_frame_size[9000]</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_jumbo_frame_size[9002]</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_learning_address</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_learning_address_rate</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_learning_illegal_address</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_relearning_on_different_vlans</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_remove_restore_from_vlan</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_robustness_macs</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_static_entries</td><td>pass</td><td></td></tr>
<tr><td>test_bridging_unreg_traffic_ipv6</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_interact_acl_with_dyn_traps</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_interact_dyn_traps_lag</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_interact_static_traps_disabled</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_same_rule_pref[single_block]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_same_rule_pref[shared_block]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_rule_priority[single_block]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_rule_priority[shared_block]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_basic[l2]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_basic[l3]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_basic[l4]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_random</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_policer_log</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[bit]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[kbit]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[gbit]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[bps]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[kbps]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[mbps]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[gbps]</td><td>pass</td><td></td></tr>
<tr><td>test_devlink_diff_rate_units[tbps]</td><td>pass</td><td></td></tr>
<tr><td>test_ecmp_nexthops_down[1]</td><td>pass</td><td></td></tr>
<tr><td>test_ecmp_hash_policy</td><td>pass</td><td></td></tr>
<tr><td>test_ecmp_traffic_distribution[nexthop_down]</td><td>pass</td><td></td></tr>
<tr><td>test_ecmp_traffic_distribution[dynamic]</td><td>pass</td><td></td></tr>
<tr><td>test_hw_drop_l3[1]</td><td>pass</td><td></td></tr>
<tr><td>test_ifupdown2_ipv4_ecmp</td><td>pass</td><td></td></tr>
<tr><td>test_ifupdown2_lacp</td><td>pass</td><td></td></tr>
<tr><td>test_ifupdown2_acl_random[single_block-acl_random]</td><td>pass</td><td></td></tr>
<tr><td>test_ifupdown2_acl_random[single_block-acl_and_trap_policer]</td><td>pass</td><td></td></tr>
<tr><td>test_ifupdown2_acl_random[shared_block-acl_and_trap_policer]</td><td>pass</td><td></td></tr>
<tr><td>test_ifupdown2_stp[stp]</td><td>pass</td><td></td></tr>
<tr><td>test_ifupdown2_stp[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_igmp_snooping_diff_source_addrs</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_addr</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_dynamic_arp</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_static_arp</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_static_arp_with_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_arp_reachable_timeout</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_arp_ageing</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_bm_traffic_forwarding</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_class_a_dis</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_class_b_dis</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_class_c_dis</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_class_d_dis</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_class_e_dis</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_en_dis_fwd</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_default_gw</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_not_connected_gw</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_icmp_disabled</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_ping_stability</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_ping_static_ip</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_fwd_disable</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_oversized_mtu</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_nexthop_route</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_route_between_vlan_devs</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_nexthop_static_route</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_two_routes_to_same_net</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_basic_config</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_flags</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_secondary_addr</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_on_bridge</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_on_bridge_vlan</td><td>pass</td><td></td></tr>
<tr><td>test_ipv64_nh_reconfig</td><td>pass</td><td></td></tr>
<tr><td>test_ipv64_nh_routes</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_nei_ageing</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_nei_change</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_route_default_offload</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_route_lpm</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_nh_state</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_route_metrics</td><td>pass</td><td></td></tr>
<tr><td>test_ipv6_icmp</td><td>pass</td><td></td></tr>
<tr><td>test_lacp_root_port[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_lacp_root_port[stp]</td><td>pass</td><td></td></tr>
<tr><td>test_lacp_acl_negative</td><td>pass</td><td></td></tr>
<tr><td>test_lacp_unsupported_modes</td><td>pass</td><td></td></tr>
<tr><td>test_lacp_max_lags</td><td>pass</td><td></td></tr>
<tr><td>test_lacp_max_ports_in_lags</td><td>pass</td><td></td></tr>
<tr><td>test_lacp_root_bridge_selection_stp[stp]</td><td>pass</td><td></td></tr>
<tr><td>test_lacp_root_bridge_selection_stp[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_lacp_all_vlan_modes</td><td>pass</td><td></td></tr>
<tr><td>test_lldp_transmitted[basic]</td><td>pass</td><td></td></tr>
<tr><td>test_lldp_transmitted[mandatory]</td><td>pass</td><td></td></tr>
<tr><td>test_lldp_transmitted[optional]</td><td>pass</td><td></td></tr>
<tr><td>test_lldp_tx[disabled]</td><td>pass</td><td></td></tr>
<tr><td>test_lldp_tx[port_down]</td><td>pass</td><td></td></tr>
<tr><td>test_lldp_tx[interval]</td><td>pass</td><td></td></tr>
<tr><td>test_lldp_tx_hold</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[port-ipv4]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[port-l2]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[port-udp]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[port-tcp]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[shared_block-ipv4]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[shared_block-l2]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[shared_block-udp]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_basic_functionality[shared_block-tcp]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_interact_with_acl_drop</td><td>pass</td><td></td></tr>
<tr><td>test_policer_interaction_span</td><td>pass</td><td></td></tr>
<tr><td>test_policer_bond_rule_not_offloaded</td><td>pass</td><td></td></tr>
<tr><td>test_policer_rate_per_rule</td><td>pass</td><td></td></tr>
<tr><td>test_policer_rate_config[IEC]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_rate_config[SI]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_rules_priority[port]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_rules_priority[shared_block]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_same_pref_rules[port]</td><td>pass</td><td></td></tr>
<tr><td>test_policer_same_pref_rules[shared_block]</td><td>pass</td><td></td></tr>
<tr><td>test_port_isolation_basic_functionality</td><td>pass</td><td></td></tr>
<tr><td>test_port_isolation_incremental_mac_addresses</td><td>pass</td><td></td></tr>
<tr><td>test_port_isolation_interaction_br_storm_control</td><td>pass</td><td></td></tr>
<tr><td>test_port_isolation_interaction_mc_and_br_storm_control</td><td>pass</td><td></td></tr>
<tr><td>test_port_isolation_interaction_ports_inside_lag</td><td>pass</td><td></td></tr>
<tr><td>test_port_isolation_interaction_span_rule</td><td>pass</td><td></td></tr>
<tr><td>test_port_isolation_interaction_unk_uc_storm_control</td><td>pass</td><td></td></tr>
<tr><td>test_port_isolation_interaction_vlan_membership</td><td>pass</td><td></td></tr>
<tr><td>test_port_isolation_maximum_isolated_ports_on_bridge</td><td>pass</td><td></td></tr>
<tr><td>test_port_isolation_vlan_interfaces</td><td>pass</td><td></td></tr>
<tr><td>test_qos_dscp_remarking</td><td>pass</td><td></td></tr>
<tr><td>test_qos_shaper[L2]</td><td>pass</td><td></td></tr>
<tr><td>test_qos_shaper[L3]</td><td>pass</td><td></td></tr>
<tr><td>test_qos_trust_mode[sp-L2]</td><td>pass</td><td></td></tr>
<tr><td>test_qos_trust_mode[sp-L3]</td><td>pass</td><td></td></tr>
<tr><td>test_qos_trust_mode[wrr-L2]</td><td>pass</td><td></td></tr>
<tr><td>test_qos_trust_mode[wrr-L3]</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_br_and_mc_lag_and_vlan_membership</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_br_and_unk_un_and_vlan_membership</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_broadcast_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_interaction_policer_rules</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_mc_lag_and_vlan_membership</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_rule_set_for_br_and_mc_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_rule_set_for_br_and_unk_uc_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_unk_un_lag_and_vlan_membership</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_unknown_unicast_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_storm_control_unregistered_multicast_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_storm_negative_known_unicast_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_stp_bpdu_guard</td><td>pass</td><td></td></tr>
<tr><td>test_stp_forward_delay</td><td>pass</td><td></td></tr>
<tr><td>test_stp_max_age</td><td>pass</td><td></td></tr>
<tr><td>test_stp_root_guard</td><td>pass</td><td></td></tr>
<tr><td>test_stp_topology_convergence_with_down_link[stp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_topology_convergence_with_down_link[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_blocked_ports[stp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_blocked_ports[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_bpdu_filter[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_hello_time[stp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_hello_time[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_select_root_bridge[stp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_select_root_bridge[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_select_root_port[stp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_select_root_port[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_root_bridge_based_on_mac[stp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_root_bridge_based_on_mac[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_select_root_port_on_cost[stp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_select_root_port_on_cost[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_traffic_during_mode_change[stp]</td><td>pass</td><td></td></tr>
<tr><td>test_stp_switching_off_on[rstp]</td><td>pass</td><td></td></tr>
<tr><td>test_ipv4_route_table_fill</td><td>pass</td><td></td></tr>
<tr><td>test_acl_table_size</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_all_supported_modes_broadcast</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_all_supported_modes_multicast</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_all_supported_modes_unicast</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_can_set_max_vlans</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_can_not_add_interface_to_vlan_wo_bridge</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_default_configuration_with_[broadcast]</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_default_configuration_with_[multicast]</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_default_configuration_with_[unicast]</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_default_configuration_with_[unknown_unicast]</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_basic_functionality</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_changing_default_pvid</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_with_increment_macs</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_priority_tag</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_switching_vlan_modes_via_cli</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_tagged_ports_with_[broadcast]</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_tagged_ports_with_[multicast]</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_tagged_ports_with_[unicast]</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_tagged_packet_size</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_untagged_ports_with_[broadcast]</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_untagged_ports_with_[multicast]</td><td>pass</td><td></td></tr>
<tr><td>test_vlan_untagged_ports_with_[unicast]</td><td>pass</td><td></td></tr>
<tr><td>test_l1_autodetect[10-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autodetect[10-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autodetect[100-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autodetect[100-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autodetect[1000-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autoneg[10-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autoneg[10-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autoneg[100-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autoneg[100-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_autoneg[1000-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_settings_[autodetect]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_settings_[autoneg]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_forced_speed_[10-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_forced_speed_[10-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_forced_speed_[100-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_forced_speed_[100-half]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_forced_speed_[1000-full]</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_mixed_speed</td><td>skipped</td><td></td></tr>
<tr><td>test_l1_link_up_state_software_power_cycle</td><td>skipped</td><td></td></tr>
<tr><td>test_ipv4_ping_size</td><td>skipped</td><td></td></tr>
<tr><td>test_ipv4_fragmentation</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_advert_interval</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_advert_overflow</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_basic_on[port]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_basic_on[bridge]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_basic_down_on[port]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_basic_down_on[bridge]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_ifupdown2</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_and_stp</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_and_acl</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_preempt_on[port]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_preempt_on[bridge]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_priority_on[port]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_priority_on[bridge]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_under_traffic[bridge]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_under_traffic[vlan]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_under_traffic[port]</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_master_and_backup</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_multiple_addr</td><td>skipped</td><td></td></tr>
<tr><td>test_vrrp_max_instances</td><td>skipped</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>l3_tests</td><td>3</td><td>3</td> <td>0</td><td>0</td><td>0</td><td>300.780</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_arp_flush_w_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_route_add_del</td><td>pass</td><td></td></tr>
<tr><td>test_link_up_down</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>platform</td><td>5</td><td>5</td> <td>0</td><td>0</td><td>0</td><td>1.237</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_lldp_neighor</td><td>pass</td><td></td></tr>
<tr><td>test_onlpdump</td><td>pass</td><td></td></tr>
<tr><td>test_poe_link_enable_disable_one_port</td><td>pass</td><td></td></tr>
<tr><td>test_poe_link_enable_disable_all_ports</td><td>pass</td><td></td></tr>
<tr><td>test_poe_link_enable_disable_connected_ports</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>store_bringup</td><td>0</td><td>0</td> <td>0</td><td>0</td><td>0</td><td>0.671</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
</table>
</details></td></tr>
<tr><td>stress_tests</td><td>3</td><td>3</td> <td>0</td><td>0</td><td>1</td><td>578.741</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_stress_cpu_usage</td><td>pass</td><td></td></tr>
<tr><td>test_stress_mem_usage</td><td>pass</td><td></td></tr>
<tr><td>test_stress_sock_usage</td><td>pass</td><td></td></tr>
<tr><td>test_stress_exhause_disk_space</td><td>skipped</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>system_health</td><td>1</td><td>1</td> <td>0</td><td>0</td><td>0</td><td>17.441</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_check_and_validate_switch_links</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>system_wide_testing</td><td>3</td><td>3</td> <td>0</td><td>0</td><td>0</td><td>3229.432</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_system_wide_restart_and_service_reloads</td><td>pass</td><td></td></tr>
<tr><td>test_switch_reload_all</td><td>pass</td><td></td></tr>
<tr><td>test_switch_reload_one_switch</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>tc_tests</td><td>2</td><td>2</td> <td>0</td><td>0</td><td>0</td><td>1186.327</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_tc_flower_persistency_w_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_tc_flower_persistency_atomic_update_w_traffic</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>test</td><td>0</td><td>0</td> <td>0</td><td>0</td><td>0</td><td>0.848</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
</table>
</details></td></tr>
<tr><td>traffic_tests</td><td>3</td><td>3</td> <td>0</td><td>0</td><td>0</td><td>699.468</td></tr>
<tr><td colspan="6"><details><summary>&emsp;Results
</summary>
<table>
<tr><th>Test Name</th><th>Status</th><th>Message</th></tr>
<tr><td>test_all_ports_tgen_w_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_basic_tgen_w_traffic</td><td>pass</td><td></td></tr>
<tr><td>test_tgen_link_speed_change</td><td>pass</td><td></td></tr>
</table>
</details></td></tr>
<tr><td>TOTAL</td><td>361</td><td>287</td> <td>72</td><td>2</td><td>41</td><td>85996.578</td></tr>
</table>
