### PR TITLE
Stop traffic before testing loss percentage

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_bridge.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_bridge.py
@@ -14,6 +14,7 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_setup_streams,
     tgen_utils_get_loss,
     tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
     tgen_utils_get_swp_info,
 )
 pytestmark = [pytest.mark.suite_functional_lacp,
@@ -142,6 +143,7 @@ async def test_lacp_routing_over_bridge(testbed):
             raise  # will re-raise the AssertionError
     await tgen_utils_start_traffic(tgen_dev)
     await asyncio.sleep(25)
+    await tgen_utils_stop_traffic(tgen_dev)
 
     # 9. Verify traffic received on bridge
     stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Traffic Item Statistics')

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_lacp.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_lacp.py
@@ -136,10 +136,10 @@ async def test_lacp_routing_over_lacp(testbed):
             raise  # will re-raise the AssertionError
     await tgen_utils_start_traffic(tgen_dev)
     await asyncio.sleep(25)
+    await tgen_utils_stop_traffic(tgen_dev)
 
     # 9. Verify no traffic loss
     stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Traffic Item Statistics')
     for row in stats.Rows:
         err_msg = f"Expected 0.00 loss, actual {float(row['Loss %'])}"
         assert isclose(tgen_utils_get_loss(row), 0.00, abs_tol=0.1), err_msg
-    await tgen_utils_stop_traffic(tgen_dev)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_vlan_device.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_routing_over_vlan_device.py
@@ -15,6 +15,7 @@ from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_traffic_stats,
     tgen_utils_setup_streams,
     tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
     tgen_utils_get_swp_info,
     tgen_utils_get_loss,
 )
@@ -164,6 +165,7 @@ async def test_lacp_routing_over_vlan_device(testbed):
             raise  # will re-raise the AssertionError
     await tgen_utils_start_traffic(tgen_dev)
     await asyncio.sleep(25)
+    await tgen_utils_stop_traffic(tgen_dev)
 
     # 9. Verify no traffic loss
     stats = await tgen_utils_get_traffic_stats(tgen_dev, 'Traffic Item Statistics')


### PR DESCRIPTION
If loss percentage is tested while traffic is ongoing, there is a possibility of packets that are still in route not being counted, leading to unnecessary test failure. Solution is to stop traffic before checking loss percentage.