### PR TITLE
Optimize Ixnet Traffic Items and Endpoints using BatchAdd

### DIFF
--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -57,7 +57,7 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
                 IxnetworkIxiaClientImpl.ip_eps = []
                 IxnetworkIxiaClientImpl.eth_eps = []
                 IxnetworkIxiaClientImpl.raw_eps = []
-                IxnetworkIxiaClientImpl.tis = []
+                IxnetworkIxiaClientImpl.tis = None
             return 0, ''
         params = kwarg['params']
         if not params or not params[0] or 'test' in device.host_name:
@@ -90,7 +90,7 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             IxnetworkIxiaClientImpl.ip_eps = []
             IxnetworkIxiaClientImpl.eth_eps = []
             IxnetworkIxiaClientImpl.raw_eps = []
-            IxnetworkIxiaClientImpl.tis = []
+            IxnetworkIxiaClientImpl.tis = None
             crc = IxnetworkIxiaClientImpl.ixnet.Traffic.TrafficItem.ConfigElement._SDM_ENUM_MAP['crc']
             IxnetworkIxiaClientImpl.bad_crc = {True: crc[0], False: crc[1]}
             IxnetworkIxiaClientImpl.stack_template = {
@@ -415,45 +415,49 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
         else:
             ixia_traffic_type = traffic_type
 
-        for ip1, ep1, rep1, rr1 in zip(cls.ip_eps, cls.eth_eps, cls.raw_eps, cls.rr_eps):
-            if any(src in pkt_data and endpoint.Name not in pkt_data[src]
-                   for src, endpoint in (('ip_source', ip1), ('ep_source', ep1), ('bgp_source', rr1))):
-                continue
-            device.applog.info(f'Creating {traffic_type} traffic stream')
-            ti = cls.ixnet.Traffic.TrafficItem.add(
-                Name=name, TrafficType=ixia_traffic_type
-            )
-            ep_count = 0
-            for ip2, ep2, rep2, rr2 in zip(cls.ip_eps, cls.eth_eps, cls.raw_eps, cls.rr_eps):
-                if ep1 == ep2 and not pkt_data.get('allowSelfDestined', False):
-                    continue
-                if any(dst in pkt_data and endpoint.Name not in pkt_data[dst]
-                       for dst, endpoint in (('ip_destination', ip2),
-                                             ('ep_destination', ep2),
-                                             ('bgp_destination', rr2))):
-                    continue
+        # Get endpoint names up front to minimize API interaction within BatchAdds
+        endpoint_names = {endpoint: endpoint.Name for endpoint in cls.ip_eps + cls.eth_eps + cls.rr_eps}
+        # Filter sources and dests based on pkt_data source/dest parameters
+        endpoint_sources = []
+        endpoint_dests = []
+        for ip, ep, rep, rr in zip(cls.ip_eps, cls.eth_eps, cls.raw_eps, cls.rr_eps):
+            if not any(src in pkt_data and endpoint_names[endpoint] not in pkt_data[src]
+                       for src, endpoint in (('ip_source', ip), ('ep_source', ep), ('bgp_source', rr))):
+                endpoint_sources.append((ip, ep, rep, rr))
+            if not any(dst in pkt_data and endpoint_names[endpoint] not in pkt_data[dst]
+                       for dst, endpoint in (('ip_destination', ip), ('ep_destination', ep), ('bgp_destination', rr))):
+                endpoint_dests.append((ip, ep, rep, rr))
+        # Batch Add Traffic Items
+        with BatchAdd(IxnetworkIxiaClientImpl.ixnet):
+            for _ in range(len(endpoint_sources)):
+                device.applog.info(f'Creating {traffic_type} traffic stream')
+                cls.ixnet.Traffic.TrafficItem.add(
+                    Name=name, TrafficType=ixia_traffic_type, Enabled=True
+                )
 
-                src_name, dst_name = None, None
-                if traffic_type in ('ipv4', 'ipv6'):
-                    src, dst = ip1, ip2
-                elif traffic_type == 'bgp':
-                    src, dst = rr1, rr2
-                elif traffic_type in ('raw', 'bpdu', 'custom'):
-                    src, dst = rep1, rep2
-                    src_name, dst_name = ep1.Name, ep2.Name
-                else:
-                    src, dst = ep1, ep2
+        # Collect and Save Traffic Items
+        cls.tis = IxnetworkIxiaClientImpl.ixnet.Traffic.TrafficItem.find()
+        # Batch Add Endpoints to Traffic Items
+        with BatchAdd(IxnetworkIxiaClientImpl.ixnet):
+            for (ip1, ep1, rep1, rr1), ti in zip(endpoint_sources, cls.tis):
+                for ip2, ep2, rep2, rr2 in endpoint_dests:
+                    if ep1 == ep2 and not pkt_data.get('allowSelfDestined', False):
+                        continue
+                    src_name, dst_name = None, None
+                    if traffic_type in ('ipv4', 'ipv6'):
+                        src, dst = ip1, ip2
+                    elif traffic_type == 'bgp':
+                        src, dst = rr1, rr2
+                    elif traffic_type in ('raw', 'bpdu', 'custom'):
+                        src, dst = rep1, rep2
+                        src_name, dst_name = endpoint_names[ep1], endpoint_names[ep2]
+                    else:
+                        src, dst = ep1, ep2
 
-                if src_name is None and dst_name is None:
-                    src_name, dst_name = src.Name, dst.Name
-                device.applog.info(f'Adding endpoint {src_name} to {dst_name}')
-
-                ti.EndpointSet.add(Sources=src, Destinations=dst)
-                ep_count += 1
-            cls.tis.append(ti)
-            ti.Enabled = True
-
-            yield ti, ep_count
+                    if src_name is None and dst_name is None:
+                        src_name, dst_name = endpoint_names[src], endpoint_names[dst]
+                    device.applog.info(f'Adding endpoint {src_name} to {dst_name}')
+                    ti.EndpointSet.add(Sources=src, Destinations=dst)
 
     def __configure_l2_stack(self, config_element, pkt_data, track_by):
         eth_stack = config_element.Stack.find(StackTypeId='^ethernet$')
@@ -653,10 +657,10 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
         return custom_stack
 
     def set_traffic(self, device, name, pkt_data):
-        for ti, ep_count in self.__create_traffic_items(device, pkt_data, name):
+        self.__create_traffic_items(device, pkt_data, name)
+        for ti in IxnetworkIxiaClientImpl.tis:
             track_by = {'trackingenabled0', 'sourceDestValuePair0'}
-            for ep in range(ep_count):
-                config_element = ti.ConfigElement.find(EndpointSetId=ep + 1)
+            for config_element in ti.ConfigElement.find():
                 self.__update_frame_rate(config_element, pkt_data)
                 config_element.FrameSize.update(
                     Type='fixed', FixedSize=pkt_data.get('frameSize', '512')
@@ -775,20 +779,20 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             # Check that Protocols are Started and Up
             protocolsSummary = SVA(IxnetworkIxiaClientImpl.ixnet, 'Protocols Summary')
             device.applog.info('Waiting for Protocols for up to 20 seconds')
-            protocolsSummary.CheckCondition('Sessions Not Started', SVA.EQUAL, 0, Timeout=10, RaiseException=False)
-            protocolsSummary.CheckCondition('Sessions Down', SVA.EQUAL, 0, Timeout=10, RaiseException=False)
-
-            for ep in IxnetworkIxiaClientImpl.ip_eps:
-                device.applog.info('Sending ARP on ' + ep.Name)
-                ep.Start()
-                if 'SendArp' in dir(ep):
-                    ep.SendArp()  # ipv4
-                else:
-                    ep.SendNs()  # ipv6
-            time.sleep(5)
+            protocols_up = (protocolsSummary.CheckCondition('Sessions Not Started', SVA.EQUAL, 0, Timeout=10, RaiseException=False)
+                            and protocolsSummary.CheckCondition('Sessions Down', SVA.EQUAL, 0, Timeout=10, RaiseException=False))
+            # Send ARPs if protocols didn't come up
+            if not protocols_up:
+                for ep in IxnetworkIxiaClientImpl.ip_eps:
+                    device.applog.info('Sending ARP on ' + ep.Name)
+                    ep.Start()
+                    if 'SendArp' in dir(ep):
+                        ep.SendArp()  # ipv4
+                    else:
+                        ep.SendNs()  # ipv6
+                time.sleep(5)
             device.applog.info('Generating Traffic')
-            for ti in IxnetworkIxiaClientImpl.tis:
-                ti.Generate()
+            IxnetworkIxiaClientImpl.tis.Generate()
             device.applog.info('Applying Traffic')
             IxnetworkIxiaClientImpl.ixnet.Traffic.Apply()
         elif command == 'stop_protocols':


### PR DESCRIPTION
* Combine adding of traffic items and 16+ endpoints into single API calls for speedup
* Skip sending ARPs when protocols are already up
* Generate all traffic items in single call rather than loop

Outcomes:
TBD